### PR TITLE
[jinyoungchoi95-issue1] User 도메인 구현 및 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id 'jacoco'
-    id 'idea'
 }
 
 group = 'com.study.realworld'
@@ -13,30 +12,6 @@ sourceCompatibility = '11'
 repositories {
     mavenCentral()
 }
-
-sourceSets {
-    integration {
-        java.srcDir "$projectDir/src/integration_test/java"
-        resources.srcDir "$projectDir/src/integration_test/resources"
-        compileClasspath += sourceSets.main.output
-        runtimeClasspath += sourceSets.main.output
-    }
-}
-idea {
-    module {
-        testSourceDirs += sourceSets.integration.java.srcDirs
-        testResourceDirs += sourceSets.integration.resources.srcDirs
-    }
-}
-task integration(type: Test) {
-    testClassesDirs = sourceSets.integration.output.classesDirs
-    classpath = sourceSets.integration.runtimeClasspath
-}
-configurations {
-    integrationImplementation.extendsFrom testImplementation
-    integrationRuntime.extendsFrom testRuntime
-}
-check.dependsOn integration
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id 'jacoco'
+    id 'idea'
 }
 
 group = 'com.study.realworld'
@@ -12,6 +13,30 @@ sourceCompatibility = '11'
 repositories {
     mavenCentral()
 }
+
+sourceSets {
+    integration {
+        java.srcDir "$projectDir/src/integration_test/java"
+        resources.srcDir "$projectDir/src/integration_test/resources"
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+idea {
+    module {
+        testSourceDirs += sourceSets.integration.java.srcDirs
+        testResourceDirs += sourceSets.integration.resources.srcDirs
+    }
+}
+task integration(type: Test) {
+    testClassesDirs = sourceSets.integration.output.classesDirs
+    classpath = sourceSets.integration.runtimeClasspath
+}
+configurations {
+    integrationImplementation.extendsFrom testImplementation
+    integrationRuntime.extendsFrom testRuntime
+}
+check.dependsOn integration
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,13 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 apply from: 'test.gradle'

--- a/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
@@ -18,6 +18,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable();
         http.authorizeRequests()
                 .antMatchers("/api/users", "/api/users/login").permitAll()
                 .anyRequest().authenticated();

--- a/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
@@ -1,0 +1,31 @@
+package com.study.realworld.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/static/**", "/templates/**", "/h2/**", "/h2-console/**");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+                .antMatchers("/api/users", "/api/users/login").permitAll()
+                .anyRequest().authenticated();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
@@ -20,8 +20,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable();
         http.authorizeRequests()
-                .antMatchers("/api/users", "/api/users/login").permitAll()
-                .anyRequest().authenticated();
+            .antMatchers("/api/users", "/api/users/login").permitAll()
+            .anyRequest().authenticated();
     }
 
     @Bean

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -5,9 +5,13 @@ import com.study.realworld.user.domain.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
 
 import static com.study.realworld.user.domain.Password.encode;
 
+@Validated
 @Service
 public class UserService {
 
@@ -20,7 +24,7 @@ public class UserService {
     }
 
     @Transactional
-    public User join(User user) {
+    public User join(@Valid User user) {
         userRepository.findByUsername(user.getUsername())
                 .ifPresent(param -> {
                     throw new RuntimeException("already user username");

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -30,20 +30,20 @@ public class UserService {
         checkOverlapByUsernameAndEmail(input.getUsername(), input.getEmail());
 
         User user = new User.Builder(input)
-                .password(encode(input.getPassword().getPassword(), passwordEncoder))
-                .build();
+            .password(encode(input.getPassword().getPassword(), passwordEncoder))
+            .build();
         return userRepository.save(user);
     }
 
     private void checkOverlapByUsernameAndEmail(Username username, Email email) {
         userRepository.findByUsername(username)
-                .ifPresent(param -> {
-                    throw new RuntimeException("already user username");
-                });
+            .ifPresent(param -> {
+                throw new RuntimeException("already user username");
+            });
         userRepository.findByEmail(email)
-                .ifPresent(param -> {
-                    throw new RuntimeException("already user email");
-                });
+            .ifPresent(param -> {
+                throw new RuntimeException("already user email");
+            });
     }
 
 }

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -31,12 +31,8 @@ public class UserService {
                 });
 
         return userRepository.save(
-                new User.Builder()
-                    .username(user.getUsername())
-                    .email(user.getEmail())
+                new User.Builder(user)
                     .password(encode(user.getPassword().getPassword(), passwordEncoder))
-                    .bio(user.getBio())
-                    .image(user.getImage())
                     .build()
         );
     }

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -4,6 +4,7 @@ import com.study.realworld.user.domain.Email;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.UserRepository;
 import com.study.realworld.user.domain.Username;
+import java.util.Optional;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,24 +27,30 @@ public class UserService {
     }
 
     @Transactional
-    public User join(@Valid User input) {
-        checkOverlapByUsernameAndEmail(input.getUsername(), input.getEmail());
+    public User join(@Valid User user) {
+        checkDuplicatedByUsernameOrEmail(user.getUsername(), user.getEmail());
 
-        User user = new User.Builder(input)
-            .password(encode(input.getPassword().getPassword(), passwordEncoder))
-            .build();
+        user.encodePassword(passwordEncoder);
         return userRepository.save(user);
     }
 
-    private void checkOverlapByUsernameAndEmail(Username username, Email email) {
-        userRepository.findByUsername(username)
+    private void checkDuplicatedByUsernameOrEmail(Username username, Email email) {
+        findByUsername(username)
             .ifPresent(param -> {
                 throw new RuntimeException("already user username");
             });
-        userRepository.findByEmail(email)
+        findByEmail(email)
             .ifPresent(param -> {
                 throw new RuntimeException("already user email");
             });
+    }
+
+    private Optional<User> findByUsername(Username username) {
+        return userRepository.findByUsername(username);
+    }
+
+    private Optional<User> findByEmail(Email email) {
+        return userRepository.findByEmail(email);
     }
 
 }

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -2,16 +2,21 @@ package com.study.realworld.user.Service;
 
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.study.realworld.user.domain.Password.encode;
 
 @Service
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public UserService(UserRepository userRepository) {
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Transactional
@@ -24,7 +29,16 @@ public class UserService {
                 .ifPresent(param -> {
                     throw new RuntimeException("already user email");
                 });
-        return userRepository.save(user);
+
+        return userRepository.save(
+                new User.Builder()
+                    .username(user.getUsername())
+                    .email(user.getEmail())
+                    .password(encode(user.getPassword().getPassword(), passwordEncoder))
+                    .bio(user.getBio())
+                    .image(user.getImage())
+                    .build()
+        );
     }
 
 }

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -1,0 +1,30 @@
+package com.study.realworld.user.Service;
+
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public User join(User user) {
+        userRepository.findByUsername(user.getUsername())
+                .ifPresent(param -> {
+                    throw new RuntimeException("already user username");
+                });
+        userRepository.findByEmail(user.getEmail())
+                .ifPresent(param -> {
+                    throw new RuntimeException("already user email");
+                });
+        return userRepository.save(user);
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -12,8 +12,6 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 
-import static com.study.realworld.user.domain.Password.encode;
-
 @Validated
 @Service
 public class UserService {

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -36,8 +36,8 @@ public class UserService {
 
         return userRepository.save(
                 new User.Builder(user)
-                    .password(encode(user.getPassword().getPassword(), passwordEncoder))
-                    .build()
+                        .password(encode(user.getPassword().getPassword(), passwordEncoder))
+                        .build()
         );
     }
 

--- a/src/main/java/com/study/realworld/user/Service/UserService.java
+++ b/src/main/java/com/study/realworld/user/Service/UserService.java
@@ -1,7 +1,9 @@
 package com.study.realworld.user.Service;
 
+import com.study.realworld.user.domain.Email;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.UserRepository;
+import com.study.realworld.user.domain.Username;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,21 +26,24 @@ public class UserService {
     }
 
     @Transactional
-    public User join(@Valid User user) {
-        userRepository.findByUsername(user.getUsername())
+    public User join(@Valid User input) {
+        checkOverlapByUsernameAndEmail(input.getUsername(), input.getEmail());
+
+        User user = new User.Builder(input)
+                .password(encode(input.getPassword().getPassword(), passwordEncoder))
+                .build();
+        return userRepository.save(user);
+    }
+
+    private void checkOverlapByUsernameAndEmail(Username username, Email email) {
+        userRepository.findByUsername(username)
                 .ifPresent(param -> {
                     throw new RuntimeException("already user username");
                 });
-        userRepository.findByEmail(user.getEmail())
+        userRepository.findByEmail(email)
                 .ifPresent(param -> {
                     throw new RuntimeException("already user email");
                 });
-
-        return userRepository.save(
-                new User.Builder(user)
-                        .password(encode(user.getPassword().getPassword(), passwordEncoder))
-                        .build()
-        );
     }
 
 }

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -3,9 +3,8 @@ package com.study.realworld.user.controller;
 import com.study.realworld.user.Service.UserService;
 import com.study.realworld.user.controller.request.UserJoinRequest;
 import com.study.realworld.user.controller.response.UserResponse;
-import com.study.realworld.user.domain.User;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static com.study.realworld.user.controller.request.UserJoinRequest.*;
@@ -17,16 +16,14 @@ public class UserController {
 
     private final UserService userService;
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
-
     public UserController(UserService userService) {
         this.userService = userService;
     }
 
-//    @PostMapping("/users")
-//    public UserResponse join(@RequestBody UserJoinRequest request) {
-////        User user = userService.join(from(request));
-//        User user = userService.join(new User.Builder().build());
-//        return  fromUser(user);
-//    }
+    @PostMapping("/users")
+    public ResponseEntity<UserResponse> join(@RequestBody UserJoinRequest request) {
+        return new ResponseEntity<>(
+                fromUser(userService.join(from(request))), HttpStatus.OK
+        );
+    }
 }

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -1,0 +1,32 @@
+package com.study.realworld.user.controller;
+
+import com.study.realworld.user.Service.UserService;
+import com.study.realworld.user.controller.request.UserJoinRequest;
+import com.study.realworld.user.controller.response.UserResponse;
+import com.study.realworld.user.domain.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.*;
+
+import static com.study.realworld.user.controller.request.UserJoinRequest.*;
+import static com.study.realworld.user.controller.response.UserResponse.fromUser;
+
+@RequestMapping("/api")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+//    @PostMapping("/users")
+//    public UserResponse join(@RequestBody UserJoinRequest request) {
+////        User user = userService.join(from(request));
+//        User user = userService.join(new User.Builder().build());
+//        return  fromUser(user);
+//    }
+}

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
     @PostMapping("/users")
     public ResponseEntity<UserResponse> join(@RequestBody UserJoinRequest request) {
         return new ResponseEntity<>(
-                fromUser(userService.join(from(request))), HttpStatus.OK
+            fromUser(userService.join(from(request))), HttpStatus.OK
         );
     }
 }

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.study.realworld.user.controller;
 
-import com.study.realworld.user.Service.UserService;
+import com.study.realworld.user.service.UserService;
 import com.study.realworld.user.controller.request.UserJoinRequest;
 import com.study.realworld.user.controller.response.UserResponse;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -27,7 +27,13 @@ public class UserJoinRequest {
     @JsonProperty("image")
     private String image;
 
-    protected UserJoinRequest() {
+    public UserJoinRequest(String username, String email, String password, String bio,
+        String image) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.bio = bio;
+        this.image = image;
     }
 
     public String getUsername() {
@@ -48,15 +54,6 @@ public class UserJoinRequest {
 
     public String getImage() {
         return image;
-    }
-
-    public UserJoinRequest(String username, String email, String password, String bio,
-        String image) {
-        this.username = username;
-        this.email = email;
-        this.password = password;
-        this.bio = bio;
-        this.image = image;
     }
 
     public static User from(UserJoinRequest request) {

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -1,0 +1,58 @@
+package com.study.realworld.user.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.Password;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.Username;
+
+@JsonTypeName(value = "user")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+public class UserJoinRequest {
+    @JsonProperty("username")
+    private String username;
+    @JsonProperty("email")
+    private String email;
+    @JsonProperty("password")
+    private String password;
+    @JsonProperty("bio")
+    private String bio;
+    @JsonProperty("image")
+    private String image;
+
+    protected UserJoinRequest() {
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public static User from(UserJoinRequest request) {
+        return new User.Builder()
+                .username(new Username(request.getUsername()))
+                .email(new Email(request.getEmail()))
+                .password(new Password(request.getPassword()))
+                .bio(request.getBio())
+                .image(request.getImage())
+                .build();
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -27,6 +27,9 @@ public class UserJoinRequest {
     @JsonProperty("image")
     private String image;
 
+    protected UserJoinRequest() {
+    }
+
     public UserJoinRequest(String username, String email, String password, String bio,
         String image) {
         this.username = username;

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -11,14 +11,19 @@ import com.study.realworld.user.domain.Username;
 @JsonTypeName(value = "user")
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 public class UserJoinRequest {
+
     @JsonProperty("username")
     private String username;
+
     @JsonProperty("email")
     private String email;
+
     @JsonProperty("password")
     private String password;
+
     @JsonProperty("bio")
     private String bio;
+
     @JsonProperty("image")
     private String image;
 
@@ -45,7 +50,8 @@ public class UserJoinRequest {
         return image;
     }
 
-    public UserJoinRequest(String username, String email, String password, String bio, String image) {
+    public UserJoinRequest(String username, String email, String password, String bio,
+        String image) {
         this.username = username;
         this.email = email;
         this.password = password;
@@ -55,12 +61,12 @@ public class UserJoinRequest {
 
     public static User from(UserJoinRequest request) {
         return new User.Builder()
-                .username(new Username(request.getUsername()))
-                .email(new Email(request.getEmail()))
-                .password(new Password(request.getPassword()))
-                .bio(request.getBio())
-                .image(request.getImage())
-                .build();
+            .username(new Username(request.getUsername()))
+            .email(new Email(request.getEmail()))
+            .password(new Password(request.getPassword()))
+            .bio(request.getBio())
+            .image(request.getImage())
+            .build();
     }
 
 }

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -45,6 +45,14 @@ public class UserJoinRequest {
         return image;
     }
 
+    protected UserJoinRequest(String username, String email, String password, String bio, String image) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.bio = bio;
+        this.image = image;
+    }
+
     public static User from(UserJoinRequest request) {
         return new User.Builder()
                 .username(new Username(request.getUsername()))

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -45,7 +45,7 @@ public class UserJoinRequest {
         return image;
     }
 
-    protected UserJoinRequest(String username, String email, String password, String bio, String image) {
+    public UserJoinRequest(String username, String email, String password, String bio, String image) {
         this.username = username;
         this.email = email;
         this.password = password;

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -60,7 +60,7 @@ public class UserJoinRequest {
     }
 
     public static User from(UserJoinRequest request) {
-        return new User.Builder()
+        return User.Builder()
             .username(new Username(request.getUsername()))
             .email(new Email(request.getEmail()))
             .password(new Password(request.getPassword()))

--- a/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
+++ b/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
@@ -10,12 +10,16 @@ import static java.lang.String.valueOf;
 @JsonTypeName("user")
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 public class UserResponse {
+
     @JsonProperty("username")
     private final String username;
+
     @JsonProperty("email")
     private final String email;
+
     @JsonProperty("bio")
     private final String bio;
+
     @JsonProperty("image")
     private final String image;
 
@@ -28,10 +32,10 @@ public class UserResponse {
 
     public static UserResponse fromUser(User user) {
         return new UserResponse(
-                valueOf(user.getUsername()),
-                valueOf(user.getEmail()),
-                valueOf(user.getBio()),
-                valueOf(user.getImage())
+            valueOf(user.getUsername()),
+            valueOf(user.getEmail()),
+            valueOf(user.getBio()),
+            valueOf(user.getImage())
         );
     }
 

--- a/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
+++ b/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
@@ -30,15 +30,6 @@ public class UserResponse {
         this.image = image;
     }
 
-    public static UserResponse fromUser(User user) {
-        return new UserResponse(
-            valueOf(user.getUsername()),
-            valueOf(user.getEmail()),
-            valueOf(user.getBio()),
-            valueOf(user.getImage())
-        );
-    }
-
     public String getUsername() {
         return username;
     }
@@ -53,6 +44,15 @@ public class UserResponse {
 
     public String getImage() {
         return image;
+    }
+
+    public static UserResponse fromUser(User user) {
+        return new UserResponse(
+            valueOf(user.getUsername()),
+            valueOf(user.getEmail()),
+            valueOf(user.getBio()),
+            valueOf(user.getImage())
+        );
     }
 
 }

--- a/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
+++ b/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
@@ -1,0 +1,54 @@
+package com.study.realworld.user.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.study.realworld.user.domain.User;
+
+import static java.lang.String.valueOf;
+
+@JsonTypeName("user")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+public class UserResponse {
+    @JsonProperty("username")
+    private final String username;
+    @JsonProperty("email")
+    private final String email;
+    @JsonProperty("bio")
+    private final String bio;
+    @JsonProperty("image")
+    private final String image;
+
+    protected UserResponse(String username, String email, String bio, String image) {
+        this.username = username;
+        this.email = email;
+        this.bio = bio;
+        this.image = image;
+    }
+
+    public static UserResponse fromUser(User user) {
+        return new UserResponse(
+                valueOf(user.getUsername()),
+                valueOf(user.getEmail()),
+                valueOf(user.getBio()),
+                valueOf(user.getImage())
+        );
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/domain/Email.java
+++ b/src/main/java/com/study/realworld/user/domain/Email.java
@@ -22,8 +22,12 @@ public class Email {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Email email = (Email) o;
         return Objects.equals(address, email.address);
     }
@@ -37,4 +41,5 @@ public class Email {
     public String toString() {
         return address;
     }
+
 }

--- a/src/main/java/com/study/realworld/user/domain/Email.java
+++ b/src/main/java/com/study/realworld/user/domain/Email.java
@@ -1,12 +1,16 @@
 package com.study.realworld.user.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import javax.validation.constraints.NotEmpty;
 import java.util.Objects;
 
+@Embeddable
 public class Email {
 
     @NotEmpty(message = "address must be provided.")
     @javax.validation.constraints.Email(message = "Invalid email address")
+    @Column(name = "email", length = 50, nullable = false)
     private String address;
 
     protected Email() {

--- a/src/main/java/com/study/realworld/user/domain/Email.java
+++ b/src/main/java/com/study/realworld/user/domain/Email.java
@@ -1,0 +1,32 @@
+package com.study.realworld.user.domain;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.Objects;
+
+public class Email {
+
+    @NotEmpty(message = "address must be provided.")
+    @javax.validation.constraints.Email(message = "Invalid email address")
+    private String address;
+
+    protected Email() {
+    }
+
+    public Email(String address) {
+        this.address = address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Email email = (Email) o;
+        return Objects.equals(address, email.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address);
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/domain/Email.java
+++ b/src/main/java/com/study/realworld/user/domain/Email.java
@@ -10,7 +10,7 @@ public class Email {
 
     @NotEmpty(message = "address must be provided.")
     @javax.validation.constraints.Email(message = "Invalid email address")
-    @Column(name = "email", length = 50, nullable = false)
+    @Column(name = "email", length = 50, unique = true, nullable = false)
     private String address;
 
     protected Email() {

--- a/src/main/java/com/study/realworld/user/domain/Email.java
+++ b/src/main/java/com/study/realworld/user/domain/Email.java
@@ -33,4 +33,8 @@ public class Email {
         return Objects.hash(address);
     }
 
+    @Override
+    public String toString() {
+        return address;
+    }
 }

--- a/src/main/java/com/study/realworld/user/domain/Password.java
+++ b/src/main/java/com/study/realworld/user/domain/Password.java
@@ -17,15 +17,15 @@ public class Password {
     @Column(name = "password", nullable = false)
     private String password;
 
-    public String getPassword() {
-        return password;
-    }
-
     protected Password() {
     }
 
     public Password(String password) {
         this.password = password;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     public static Password encode(Password password, PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/study/realworld/user/domain/Password.java
+++ b/src/main/java/com/study/realworld/user/domain/Password.java
@@ -1,0 +1,33 @@
+package com.study.realworld.user.domain;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+public class Password {
+
+    @NotBlank(message = "password must be provided.")
+    @Size(min = 6, max = 20, message = "password length must be between 6 and 20 characters.")
+    private String password;
+
+    public String getPassword() {
+        return password;
+    }
+
+    protected Password() {
+    }
+
+    public Password(String password) {
+        this.password = password;
+    }
+
+    public static Password encode(String password, PasswordEncoder passwordEncoder) {
+        return new Password(passwordEncoder.encode(password));
+    }
+
+    public boolean matchPassword(String rawPassword, PasswordEncoder passwordEncoder) {
+        return passwordEncoder.matches(rawPassword, this.password);
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/domain/Password.java
+++ b/src/main/java/com/study/realworld/user/domain/Password.java
@@ -1,5 +1,7 @@
 package com.study.realworld.user.domain;
 
+import static java.lang.String.valueOf;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.Column;
@@ -26,8 +28,8 @@ public class Password {
         this.password = password;
     }
 
-    public static Password encode(String password, PasswordEncoder passwordEncoder) {
-        return new Password(passwordEncoder.encode(password));
+    public static Password encode(Password password, PasswordEncoder passwordEncoder) {
+        return new Password(passwordEncoder.encode(valueOf(password)));
     }
 
     public boolean matchPassword(String rawPassword, PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/study/realworld/user/domain/Password.java
+++ b/src/main/java/com/study/realworld/user/domain/Password.java
@@ -2,13 +2,17 @@ package com.study.realworld.user.domain;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
+@Embeddable
 public class Password {
 
     @NotBlank(message = "password must be provided.")
     @Size(min = 6, max = 20, message = "password length must be between 6 and 20 characters.")
+    @Column(name = "password", nullable = false)
     private String password;
 
     public String getPassword() {

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -2,6 +2,7 @@ package com.study.realworld.user.domain;
 
 import javax.persistence.*;
 import java.util.Objects;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Table(name = "user")
@@ -61,6 +62,10 @@ public class User {
         this.password = password;
         this.bio = bio;
         this.image = image;
+    }
+
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.password = Password.encode(password, passwordEncoder);
     }
 
     @Override

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -85,6 +85,14 @@ public class User {
         return Objects.hash(email);
     }
 
+    public static Builder Builder() {
+        return new Builder();
+    }
+
+    public static Builder Builder(User user) {
+        return new Builder(user);
+    }
+
     public static class Builder {
 
         private Long id;
@@ -94,10 +102,10 @@ public class User {
         private String bio;
         private String image;
 
-        public Builder() {
+        private Builder() {
         }
 
-        public Builder(User user) {
+        private Builder(User user) {
             id = user.getId();
             username = user.getUsername();
             email = user.getEmail();

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -1,19 +1,29 @@
 package com.study.realworld.user.domain;
 
+import javax.persistence.*;
 import java.util.Objects;
 
+@Entity
+@Table(name = "user")
 public class User {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @Embedded
     private Username username;
 
+    @Embedded
     private Email email;
 
+    @Embedded
     private Password password;
 
+    @Column(name = "bio")
     private String bio;
 
+    @Column(name = "image")
     private String image;
 
     public Long getId() {

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -50,7 +50,7 @@ public class User {
         return image;
     }
 
-    protected User () {
+    protected User() {
     }
 
     private User(Long id, Username username, Email email, Password password, String bio, String image) {

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -65,7 +65,7 @@ public class User {
     }
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
-        this.password = Password.encode(password, passwordEncoder);
+        this.password = Password.encode(this.password, passwordEncoder);
     }
 
     @Override

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -86,6 +86,15 @@ public class User {
         public Builder() {
         }
 
+        public Builder(User user) {
+            id = user.getId();
+            username = user.getUsername();
+            email = user.getEmail();
+            password = user.getPassword();
+            bio = user.getBio();
+            image = user.getImage();
+        }
+
         public Builder id(Long id) {
             this.id = id;
             return this;

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -27,6 +27,19 @@ public class User {
     @Column(name = "image")
     private String image;
 
+    protected User() {
+    }
+
+    private User(Long id, Username username, Email email, Password password, String bio,
+        String image) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.bio = bio;
+        this.image = image;
+    }
+
     public Long getId() {
         return id;
     }
@@ -49,19 +62,6 @@ public class User {
 
     public String getImage() {
         return image;
-    }
-
-    protected User() {
-    }
-
-    private User(Long id, Username username, Email email, Password password, String bio,
-        String image) {
-        this.id = id;
-        this.username = username;
-        this.email = email;
-        this.password = password;
-        this.bio = bio;
-        this.image = image;
     }
 
     public void encodePassword(PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -1,0 +1,114 @@
+package com.study.realworld.user.domain;
+
+import java.util.Objects;
+
+public class User {
+
+    private Long id;
+
+    private Username username;
+
+    private Email email;
+
+    private Password password;
+
+    private String bio;
+
+    private String image;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Username getUsername() {
+        return username;
+    }
+
+    public Email getEmail() {
+        return email;
+    }
+
+    public Password getPassword() {
+        return password;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    protected User () {
+    }
+
+    private User(Long id, Username username, Email email, Password password, String bio, String image) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.bio = bio;
+        this.image = image;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(email, user.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(email);
+    }
+
+    public static class Builder {
+        private Long id;
+        private Username username;
+        private Email email;
+        private Password password;
+        private String bio;
+        private String image;
+
+        public Builder() {
+        }
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder username(Username username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder email(Email email) {
+            this.email = email;
+            return this;
+        }
+
+        public Builder password(Password password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder bio(String bio) {
+            this.bio = bio;
+            return this;
+        }
+
+        public Builder image(String image) {
+            this.image = image;
+            return this;
+        }
+
+        public User build() {
+            return new User(id, username, email, password, bio, image);
+        }
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Embedded

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -53,7 +53,8 @@ public class User {
     protected User() {
     }
 
-    private User(Long id, Username username, Email email, Password password, String bio, String image) {
+    private User(Long id, Username username, Email email, Password password, String bio,
+        String image) {
         this.id = id;
         this.username = username;
         this.email = email;
@@ -64,8 +65,12 @@ public class User {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         User user = (User) o;
         return Objects.equals(email, user.email);
     }
@@ -76,6 +81,7 @@ public class User {
     }
 
     public static class Builder {
+
         private Long id;
         private Username username;
         private Email email;

--- a/src/main/java/com/study/realworld/user/domain/UserRepository.java
+++ b/src/main/java/com/study/realworld/user/domain/UserRepository.java
@@ -1,0 +1,13 @@
+package com.study.realworld.user.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(Username username);
+
+    Optional<User> findByEmail(Email email);
+
+}

--- a/src/main/java/com/study/realworld/user/domain/Username.java
+++ b/src/main/java/com/study/realworld/user/domain/Username.java
@@ -25,8 +25,12 @@ public class Username {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Username username = (Username) o;
         return Objects.equals(name, username.name);
     }

--- a/src/main/java/com/study/realworld/user/domain/Username.java
+++ b/src/main/java/com/study/realworld/user/domain/Username.java
@@ -13,7 +13,7 @@ public class Username {
     @NotBlank(message = "username must be provided.")
     @Size(max = 20, message = "username length must be less than 20 characters.")
     @Pattern(regexp = "^[0-9a-zA-Z가-힣]*$", message = "Invalid username name")
-    @Column(name = "username", length = 20, nullable = false)
+    @Column(name = "username", length = 20, unique = true, nullable = false)
     private String name;
 
     protected Username() {

--- a/src/main/java/com/study/realworld/user/domain/Username.java
+++ b/src/main/java/com/study/realworld/user/domain/Username.java
@@ -36,4 +36,8 @@ public class Username {
         return Objects.hash(name);
     }
 
+    @Override
+    public String toString() {
+        return name;
+    }
 }

--- a/src/main/java/com/study/realworld/user/domain/Username.java
+++ b/src/main/java/com/study/realworld/user/domain/Username.java
@@ -1,0 +1,35 @@
+package com.study.realworld.user.domain;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import java.util.Objects;
+
+public class Username {
+
+    @NotBlank(message = "username must be provided.")
+    @Size(max = 20, message = "username length must be less than 20 characters.")
+    @Pattern(regexp = "^[0-9a-zA-Z가-힣]*$", message = "Invalid username name")
+    private String name;
+
+    protected Username() {
+    }
+
+    public Username(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Username username = (Username) o;
+        return Objects.equals(name, username.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/domain/Username.java
+++ b/src/main/java/com/study/realworld/user/domain/Username.java
@@ -1,15 +1,19 @@
 package com.study.realworld.user.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.util.Objects;
 
+@Embeddable
 public class Username {
 
     @NotBlank(message = "username must be provided.")
     @Size(max = 20, message = "username length must be less than 20 characters.")
     @Pattern(regexp = "^[0-9a-zA-Z가-힣]*$", message = "Invalid username name")
+    @Column(name = "username", length = 20, nullable = false)
     private String name;
 
     protected Username() {

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -1,4 +1,4 @@
-package com.study.realworld.user.Service;
+package com.study.realworld.user.service;
 
 import com.study.realworld.user.domain.Email;
 import com.study.realworld.user.domain.User;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,14 @@ spring:
     basename: i18n/messages
     encoding: UTF-8
     cache-duration: PT1H
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+    hibernate:
+      ddl-auto: none
   datasource:
     platform: h2
     driver-class-name: org.h2.Driver

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -10,7 +10,8 @@ CREATE TABLE user
     updated_at      DATETIME        DEFAULT NULL,
     deleted_at      DATETIME        DEFAULT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT unique_email UNIQUE (email)
+    CONSTRAINT unique_email UNIQUE (email),
+    CONSTRAINT unique_username UNIQUE (username)
 );
 
 CREATE TABLE follow

--- a/src/test/java/com/study/realworld/RealworldApplicationTests.java
+++ b/src/test/java/com/study/realworld/RealworldApplicationTests.java
@@ -7,7 +7,7 @@ class RealworldApplicationTests {
 
     @Test
     void main() {
-        RealworldApplication.main(new String[] {});
+        RealworldApplication.main(new String[]{});
     }
 
 }

--- a/src/test/java/com/study/realworld/RealworldApplicationTests.java
+++ b/src/test/java/com/study/realworld/RealworldApplicationTests.java
@@ -1,7 +1,6 @@
 package com.study.realworld;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
 class RealworldApplicationTests {
 

--- a/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
@@ -32,14 +32,12 @@ class UserServiceTest {
     @DisplayName("이미 존재하는 유저네임이 들어왔을 때 Exception이 발생되어야 한다.")
     void existUsernameJoinTest() {
 
-        // setup
-        when(userRepository.findByUsername(any()))
-            .thenReturn(Optional.of(new User.Builder().build()));
-
-        // given
+        // setup & given
         User user = new User.Builder().build();
+        when(userRepository.findByUsername(any()))
+            .thenReturn(Optional.of(user));
 
-        // given & when
+        // when & then
         assertThatExceptionOfType(Exception.class)
             .isThrownBy(() -> userService.join(user));
     }
@@ -48,12 +46,10 @@ class UserServiceTest {
     @DisplayName("이미 존재하는 이메일이 들어왔을 때 Exception이 발생되어야 한다.")
     void existEmailJoinTest() {
 
-        // setup
-        when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(any())).thenReturn(Optional.of(new User.Builder().build()));
-
-        // given
+        // setup & given
         User user = new User.Builder().build();
+        when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
 
         // when & then
         assertThatExceptionOfType(Exception.class)

--- a/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
@@ -1,21 +1,18 @@
 package com.study.realworld.user.Service;
 
-import com.study.realworld.user.domain.Email;
-import com.study.realworld.user.domain.User;
-import com.study.realworld.user.domain.UserRepository;
-import com.study.realworld.user.domain.Username;
+import com.study.realworld.user.domain.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +21,9 @@ class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private UserService userService;
@@ -66,19 +66,22 @@ class UserServiceTest {
         // setup & given
         when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
         when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("password")).thenReturn("encoded_password");
         User input = new User.Builder()
                 .username(new Username("username"))
                 .email(new Email("email"))
+                .password(new Password("password"))
                 .bio("bio")
                 .image("image")
                 .build();
-        when(userRepository.save(input)).thenReturn(
+        when(userRepository.save(any())).thenReturn(
                 new User.Builder()
                         .id(1L)
-                        .username(new Username("username"))
-                        .email(new Email("email"))
-                        .bio("bio")
-                        .image("image")
+                        .username(input.getUsername())
+                        .email(input.getEmail())
+                        .password(new Password("encoded_password"))
+                        .bio(input.getBio())
+                        .image(input.getImage())
                         .build()
         );
 
@@ -89,6 +92,7 @@ class UserServiceTest {
         assertThat(user.getId()).isEqualTo(1L);
         assertThat(user.getUsername()).isEqualTo(new Username("username"));
         assertThat(user.getEmail()).isEqualTo(new Email("email"));
+        assertThat(user.getPassword().getPassword()).isEqualTo(new Password("encoded_password").getPassword());
         assertThat(user.getBio()).isEqualTo("bio");
         assertThat(user.getImage()).isEqualTo("image");
     }

--- a/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
@@ -34,7 +34,7 @@ class UserServiceTest {
     void existUsernameJoinTest() {
 
         // setup & given
-        User user = new User.Builder().build();
+        User user = User.Builder().build();
         when(userRepository.findByUsername(any()))
             .thenReturn(Optional.of(user));
 
@@ -48,7 +48,7 @@ class UserServiceTest {
     void existEmailJoinTest() {
 
         // setup & given
-        User user = new User.Builder().build();
+        User user = User.Builder().build();
         when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
         when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
 
@@ -66,7 +66,7 @@ class UserServiceTest {
         when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
         Password password = new Password("password");
         when(passwordEncoder.encode(valueOf(password))).thenReturn("encoded_password");
-        User input = new User.Builder()
+        User input = User.Builder()
             .username(new Username("username"))
             .email(new Email("email"))
             .password(password)
@@ -74,7 +74,7 @@ class UserServiceTest {
             .image("image")
             .build();
         when(userRepository.save(any())).thenReturn(
-            new User.Builder()
+            User.Builder()
                 .id(1L)
                 .username(input.getUsername())
                 .email(input.getEmail())

--- a/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
@@ -1,0 +1,96 @@
+package com.study.realworld.user.Service;
+
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.UserRepository;
+import com.study.realworld.user.domain.Username;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("이미 존재하는 유저네임이 들어왔을 때 Exception이 발생되어야 한다.")
+    void existUsernameJoinTest() {
+
+        // setup
+        when(userRepository.findByUsername(any())).thenReturn(Optional.of(new User.Builder().build()));
+
+        // given
+        User user = new User.Builder().build();
+
+        // given & when
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> userService.join(user));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 이메일이 들어왔을 때 Exception이 발생되어야 한다.")
+    void existEmailJoinTest() {
+
+        // setup
+        when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(new User.Builder().build()));
+
+        // given
+        User user = new User.Builder().build();
+
+        // when & then
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> userService.join(user));
+    }
+
+    @Test
+    @DisplayName("새로운 유저가 왔을 때 정상적으로 해당 유저가 저장되고 유저 유저정보가 반환되어야 한다.")
+    void successJoinTest() {
+
+        // setup & given
+        when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+        User input = new User.Builder()
+                .username(new Username("username"))
+                .email(new Email("email"))
+                .bio("bio")
+                .image("image")
+                .build();
+        when(userRepository.save(input)).thenReturn(
+                new User.Builder()
+                        .id(1L)
+                        .username(new Username("username"))
+                        .email(new Email("email"))
+                        .bio("bio")
+                        .image("image")
+                        .build()
+        );
+
+        // when
+        User user = userService.join(input);
+
+        // then
+        assertThat(user.getId()).isEqualTo(1L);
+        assertThat(user.getUsername()).isEqualTo(new Username("username"));
+        assertThat(user.getEmail()).isEqualTo(new Email("email"));
+        assertThat(user.getBio()).isEqualTo("bio");
+        assertThat(user.getImage()).isEqualTo("image");
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
+import static java.lang.String.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,11 +64,12 @@ class UserServiceTest {
         // setup & given
         when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
         when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
-        when(passwordEncoder.encode("password")).thenReturn("encoded_password");
+        Password password = new Password("password");
+        when(passwordEncoder.encode(valueOf(password))).thenReturn("encoded_password");
         User input = new User.Builder()
             .username(new Username("username"))
             .email(new Email("email"))
-            .password(new Password("password"))
+            .password(password)
             .bio("bio")
             .image("image")
             .build();
@@ -90,7 +92,7 @@ class UserServiceTest {
         assertThat(user.getUsername()).isEqualTo(new Username("username"));
         assertThat(user.getEmail()).isEqualTo(new Email("email"));
         assertThat(user.getPassword().getPassword())
-            .isEqualTo(new Password("encoded_password").getPassword());
+            .isEqualTo("encoded_password");
         assertThat(user.getBio()).isEqualTo("bio");
         assertThat(user.getImage()).isEqualTo("image");
     }

--- a/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/Service/UserServiceTest.java
@@ -33,14 +33,15 @@ class UserServiceTest {
     void existUsernameJoinTest() {
 
         // setup
-        when(userRepository.findByUsername(any())).thenReturn(Optional.of(new User.Builder().build()));
+        when(userRepository.findByUsername(any()))
+            .thenReturn(Optional.of(new User.Builder().build()));
 
         // given
         User user = new User.Builder().build();
 
         // given & when
         assertThatExceptionOfType(Exception.class)
-                .isThrownBy(() -> userService.join(user));
+            .isThrownBy(() -> userService.join(user));
     }
 
     @Test
@@ -56,7 +57,7 @@ class UserServiceTest {
 
         // when & then
         assertThatExceptionOfType(Exception.class)
-                .isThrownBy(() -> userService.join(user));
+            .isThrownBy(() -> userService.join(user));
     }
 
     @Test
@@ -68,21 +69,21 @@ class UserServiceTest {
         when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
         when(passwordEncoder.encode("password")).thenReturn("encoded_password");
         User input = new User.Builder()
-                .username(new Username("username"))
-                .email(new Email("email"))
-                .password(new Password("password"))
-                .bio("bio")
-                .image("image")
-                .build();
+            .username(new Username("username"))
+            .email(new Email("email"))
+            .password(new Password("password"))
+            .bio("bio")
+            .image("image")
+            .build();
         when(userRepository.save(any())).thenReturn(
-                new User.Builder()
-                        .id(1L)
-                        .username(input.getUsername())
-                        .email(input.getEmail())
-                        .password(new Password("encoded_password"))
-                        .bio(input.getBio())
-                        .image(input.getImage())
-                        .build()
+            new User.Builder()
+                .id(1L)
+                .username(input.getUsername())
+                .email(input.getEmail())
+                .password(new Password("encoded_password"))
+                .bio(input.getBio())
+                .image(input.getImage())
+                .build()
         );
 
         // when
@@ -92,7 +93,8 @@ class UserServiceTest {
         assertThat(user.getId()).isEqualTo(1L);
         assertThat(user.getUsername()).isEqualTo(new Username("username"));
         assertThat(user.getEmail()).isEqualTo(new Email("email"));
-        assertThat(user.getPassword().getPassword()).isEqualTo(new Password("encoded_password").getPassword());
+        assertThat(user.getPassword().getPassword())
+            .isEqualTo(new Password("encoded_password").getPassword());
         assertThat(user.getBio()).isEqualTo("bio");
         assertThat(user.getImage()).isEqualTo("image");
     }

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -42,8 +42,8 @@ class UserControllerTest {
     @BeforeEach
     void beforeEach() {
         mockMvc = MockMvcBuilders.standaloneSetup(userController)
-                .alwaysExpect(status().isOk())
-                .build();
+            .alwaysExpect(status().isOk())
+            .build();
         objectMapper = new ObjectMapper();
     }
 
@@ -51,14 +51,15 @@ class UserControllerTest {
     void joinTest() throws Exception {
 
         // setup
-        UserJoinRequest request = new UserJoinRequest("username", "test@test.com", "password", null, null);
+        UserJoinRequest request = new UserJoinRequest("username", "test@test.com", "password", null,
+            null);
         User user = new User.Builder()
-                .username(new Username(request.getUsername()))
-                .email(new Email(request.getEmail()))
-                .password(new Password(request.getPassword()))
-                .bio(request.getBio())
-                .image(request.getImage())
-                .build();
+            .username(new Username(request.getUsername()))
+            .email(new Email(request.getEmail()))
+            .password(new Password(request.getPassword()))
+            .bio(request.getBio())
+            .image(request.getImage())
+            .build();
 
         when(userService.join(any())).thenReturn(user);
 
@@ -67,19 +68,19 @@ class UserControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(post(URL)
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print());
+            .content(objectMapper.writeValueAsString(request))
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
 
         // then
         resultActions
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
 
-                .andExpect(jsonPath("$.user.username", is("username")))
-                .andExpect(jsonPath("$.user.email", is("test@test.com")))
-                .andExpect(jsonPath("$.user.bio", is("null")))
-                .andExpect(jsonPath("$.user.image", is("null")))
+            .andExpect(jsonPath("$.user.username", is("username")))
+            .andExpect(jsonPath("$.user.email", is("test@test.com")))
+            .andExpect(jsonPath("$.user.bio", is("null")))
+            .andExpect(jsonPath("$.user.image", is("null")))
         ;
     }
 }

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -1,0 +1,85 @@
+package com.study.realworld.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.realworld.user.Service.UserService;
+import com.study.realworld.user.controller.request.UserJoinRequest;
+import com.study.realworld.user.controller.response.UserResponse;
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.Password;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.Username;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private UserController userController;
+
+    private MockMvc mockMvc;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void beforeEach() {
+        mockMvc = MockMvcBuilders.standaloneSetup(userController)
+                .alwaysExpect(status().isOk())
+                .build();
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void joinTest() throws Exception {
+
+        // setup
+        UserJoinRequest request = new UserJoinRequest("username", "test@test.com", "password", null, null);
+        User user = new User.Builder()
+                .username(new Username(request.getUsername()))
+                .email(new Email(request.getEmail()))
+                .password(new Password(request.getPassword()))
+                .bio(request.getBio())
+                .image(request.getImage())
+                .build();
+
+        when(userService.join(any())).thenReturn(user);
+
+        // given
+        final String URL = "/api/users";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(URL)
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+                .andExpect(jsonPath("$.user.username", is("username")))
+                .andExpect(jsonPath("$.user.email", is("test@test.com")))
+                .andExpect(jsonPath("$.user.bio", is("null")))
+                .andExpect(jsonPath("$.user.image", is("null")))
+        ;
+    }
+}

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -1,9 +1,8 @@
 package com.study.realworld.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.study.realworld.user.Service.UserService;
+import com.study.realworld.user.service.UserService;
 import com.study.realworld.user.controller.request.UserJoinRequest;
-import com.study.realworld.user.controller.response.UserResponse;
 import com.study.realworld.user.domain.Email;
 import com.study.realworld.user.domain.Password;
 import com.study.realworld.user.domain.User;

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -53,7 +53,7 @@ class UserControllerTest {
         // setup
         UserJoinRequest request = new UserJoinRequest("username", "test@test.com", "password", null,
             null);
-        User user = new User.Builder()
+        User user = User.Builder()
             .username(new Username(request.getUsername()))
             .email(new Email(request.getEmail()))
             .password(new Password(request.getPassword()))

--- a/src/test/java/com/study/realworld/user/controller/request/UserJoinRequestTest.java
+++ b/src/test/java/com/study/realworld/user/controller/request/UserJoinRequestTest.java
@@ -11,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class UserJoinRequestTest {
 
     @Test
-    void userJoinRequestTest() {
-        UserJoinRequest userJoinRequest = new UserJoinRequest();
-    }
-
-    @Test
     void userJoinRequestFromTest() {
 
         // given

--- a/src/test/java/com/study/realworld/user/controller/request/UserJoinRequestTest.java
+++ b/src/test/java/com/study/realworld/user/controller/request/UserJoinRequestTest.java
@@ -20,7 +20,7 @@ class UserJoinRequestTest {
 
         // given
         UserJoinRequest userJoinRequest = new UserJoinRequest(
-                "username", "test@test.com", "password", "bio", "image"
+            "username", "test@test.com", "password", "bio", "image"
         );
 
         // when
@@ -39,7 +39,7 @@ class UserJoinRequestTest {
 
         // given
         UserJoinRequest userJoinRequest = new UserJoinRequest(
-                "username", "test@test.com", "password", "bio", "image"
+            "username", "test@test.com", "password", "bio", "image"
         );
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -48,12 +48,12 @@ class UserJoinRequestTest {
 
         // when
         assertThat(result).isEqualTo(
-                "{\"user\":{\"username\":\"" + userJoinRequest.getUsername()
-                        + "\",\"email\":\"" + userJoinRequest.getEmail()
-                        + "\",\"password\":\"" + userJoinRequest.getPassword()
-                        + "\",\"bio\":\"" + userJoinRequest.getBio()
-                        + "\",\"image\":\"" + userJoinRequest.getImage()
-                        + "\"}}"
+            "{\"user\":{\"username\":\"" + userJoinRequest.getUsername()
+                + "\",\"email\":\"" + userJoinRequest.getEmail()
+                + "\",\"password\":\"" + userJoinRequest.getPassword()
+                + "\",\"bio\":\"" + userJoinRequest.getBio()
+                + "\",\"image\":\"" + userJoinRequest.getImage()
+                + "\"}}"
         );
     }
 

--- a/src/test/java/com/study/realworld/user/controller/request/UserJoinRequestTest.java
+++ b/src/test/java/com/study/realworld/user/controller/request/UserJoinRequestTest.java
@@ -1,50 +1,60 @@
 package com.study.realworld.user.controller.request;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.study.realworld.user.domain.User;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.study.realworld.user.controller.request.UserJoinRequest.from;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 class UserJoinRequestTest {
-
-    @Mock
-    private UserJoinRequest userJoinRequest;
 
     @Test
     void userJoinRequestTest() {
         UserJoinRequest userJoinRequest = new UserJoinRequest();
-        assertThat(userJoinRequest.getUsername()).isNull();
-        assertThat(userJoinRequest.getEmail()).isNull();
-        assertThat(userJoinRequest.getPassword()).isNull();
-        assertThat(userJoinRequest.getBio()).isNull();
-        assertThat(userJoinRequest.getImage()).isNull();
     }
 
     @Test
     void userJoinRequestFromTest() {
 
         // given
-        when(userJoinRequest.getUsername()).thenReturn("username");
-        when(userJoinRequest.getEmail()).thenReturn("test@test.com");
-        when(userJoinRequest.getPassword()).thenReturn("password");
-        when(userJoinRequest.getBio()).thenReturn("bio");
-        when(userJoinRequest.getImage()).thenReturn("image");
+        UserJoinRequest userJoinRequest = new UserJoinRequest(
+                "username", "test@test.com", "password", "bio", "image"
+        );
 
         // when
         User user = from(userJoinRequest);
 
         // then
-        assertThat(user.getUsername().toString()).isEqualTo("username");
-        assertThat(user.getEmail().toString()).isEqualTo("test@test.com");
+        assertThat(user.getUsername().toString()).isEqualTo(userJoinRequest.getUsername());
+        assertThat(user.getEmail().toString()).isEqualTo(userJoinRequest.getEmail());
         assertThat(user.getPassword()).isNotNull();
-        assertThat(user.getBio()).isEqualTo("bio");
-        assertThat(user.getImage()).isEqualTo("image");
+        assertThat(user.getBio()).isEqualTo(userJoinRequest.getBio());
+        assertThat(user.getImage()).isEqualTo(userJoinRequest.getImage());
+    }
+
+    @Test
+    void userJoinRequestJacksonTest() throws JsonProcessingException {
+
+        // given
+        UserJoinRequest userJoinRequest = new UserJoinRequest(
+                "username", "test@test.com", "password", "bio", "image"
+        );
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // then
+        String result = objectMapper.writeValueAsString(userJoinRequest);
+
+        // when
+        assertThat(result).isEqualTo(
+                "{\"user\":{\"username\":\"" + userJoinRequest.getUsername()
+                        + "\",\"email\":\"" + userJoinRequest.getEmail()
+                        + "\",\"password\":\"" + userJoinRequest.getPassword()
+                        + "\",\"bio\":\"" + userJoinRequest.getBio()
+                        + "\",\"image\":\"" + userJoinRequest.getImage()
+                        + "\"}}"
+        );
     }
 
 }

--- a/src/test/java/com/study/realworld/user/controller/request/UserJoinRequestTest.java
+++ b/src/test/java/com/study/realworld/user/controller/request/UserJoinRequestTest.java
@@ -1,0 +1,50 @@
+package com.study.realworld.user.controller.request;
+
+import com.study.realworld.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.study.realworld.user.controller.request.UserJoinRequest.from;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserJoinRequestTest {
+
+    @Mock
+    private UserJoinRequest userJoinRequest;
+
+    @Test
+    void userJoinRequestTest() {
+        UserJoinRequest userJoinRequest = new UserJoinRequest();
+        assertThat(userJoinRequest.getUsername()).isNull();
+        assertThat(userJoinRequest.getEmail()).isNull();
+        assertThat(userJoinRequest.getPassword()).isNull();
+        assertThat(userJoinRequest.getBio()).isNull();
+        assertThat(userJoinRequest.getImage()).isNull();
+    }
+
+    @Test
+    void userJoinRequestFromTest() {
+
+        // given
+        when(userJoinRequest.getUsername()).thenReturn("username");
+        when(userJoinRequest.getEmail()).thenReturn("test@test.com");
+        when(userJoinRequest.getPassword()).thenReturn("password");
+        when(userJoinRequest.getBio()).thenReturn("bio");
+        when(userJoinRequest.getImage()).thenReturn("image");
+
+        // when
+        User user = from(userJoinRequest);
+
+        // then
+        assertThat(user.getUsername().toString()).isEqualTo("username");
+        assertThat(user.getEmail().toString()).isEqualTo("test@test.com");
+        assertThat(user.getPassword()).isNotNull();
+        assertThat(user.getBio()).isEqualTo("bio");
+        assertThat(user.getImage()).isEqualTo("image");
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/controller/response/UserResponseTest.java
+++ b/src/test/java/com/study/realworld/user/controller/response/UserResponseTest.java
@@ -1,0 +1,34 @@
+package com.study.realworld.user.controller.response;
+
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.Username;
+import org.junit.jupiter.api.Test;
+
+import static com.study.realworld.user.controller.response.UserResponse.fromUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserResponseTest {
+
+    @Test
+    void userResponseFromUserTest() {
+
+        // given
+        User user = new User.Builder()
+                .username(new Username("username"))
+                .email(new Email("test@test.com"))
+                .bio("bio")
+                .image("image")
+                .build();
+
+        // when
+        UserResponse result = fromUser(user);
+
+        // then
+        assertThat(result.getUsername()).isEqualTo("username");
+        assertThat(result.getEmail()).isEqualTo("test@test.com");
+        assertThat(result.getBio()).isEqualTo("bio");
+        assertThat(result.getImage()).isEqualTo("image");
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/controller/response/UserResponseTest.java
+++ b/src/test/java/com/study/realworld/user/controller/response/UserResponseTest.java
@@ -1,5 +1,7 @@
 package com.study.realworld.user.controller.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.study.realworld.user.domain.Email;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.Username;
@@ -29,6 +31,28 @@ class UserResponseTest {
         assertThat(result.getEmail()).isEqualTo("test@test.com");
         assertThat(result.getBio()).isEqualTo("bio");
         assertThat(result.getImage()).isEqualTo("image");
+    }
+
+    @Test
+    void userResponseJacksonTest() throws JsonProcessingException {
+
+        // given
+        UserResponse userResponse = new UserResponse(
+                "username", "test@test.com", "bio", "image"
+        );
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // when
+        String result = objectMapper.writeValueAsString(userResponse);
+
+        // then
+        assertThat(result).isEqualTo(
+                "{\"user\":{\"username\":\"" + userResponse.getUsername()
+                        + "\",\"email\":\"" + userResponse.getEmail()
+                        + "\",\"bio\":\"" + userResponse.getBio()
+                        + "\",\"image\":\"" + userResponse.getImage()
+                        + "\"}}"
+        );
     }
 
 }

--- a/src/test/java/com/study/realworld/user/controller/response/UserResponseTest.java
+++ b/src/test/java/com/study/realworld/user/controller/response/UserResponseTest.java
@@ -16,7 +16,7 @@ class UserResponseTest {
     void userResponseFromUserTest() {
 
         // given
-        User user = new User.Builder()
+        User user = User.Builder()
             .username(new Username("username"))
             .email(new Email("test@test.com"))
             .bio("bio")

--- a/src/test/java/com/study/realworld/user/controller/response/UserResponseTest.java
+++ b/src/test/java/com/study/realworld/user/controller/response/UserResponseTest.java
@@ -17,11 +17,11 @@ class UserResponseTest {
 
         // given
         User user = new User.Builder()
-                .username(new Username("username"))
-                .email(new Email("test@test.com"))
-                .bio("bio")
-                .image("image")
-                .build();
+            .username(new Username("username"))
+            .email(new Email("test@test.com"))
+            .bio("bio")
+            .image("image")
+            .build();
 
         // when
         UserResponse result = fromUser(user);
@@ -38,7 +38,7 @@ class UserResponseTest {
 
         // given
         UserResponse userResponse = new UserResponse(
-                "username", "test@test.com", "bio", "image"
+            "username", "test@test.com", "bio", "image"
         );
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -47,11 +47,11 @@ class UserResponseTest {
 
         // then
         assertThat(result).isEqualTo(
-                "{\"user\":{\"username\":\"" + userResponse.getUsername()
-                        + "\",\"email\":\"" + userResponse.getEmail()
-                        + "\",\"bio\":\"" + userResponse.getBio()
-                        + "\",\"image\":\"" + userResponse.getImage()
-                        + "\"}}"
+            "{\"user\":{\"username\":\"" + userResponse.getUsername()
+                + "\",\"email\":\"" + userResponse.getEmail()
+                + "\",\"bio\":\"" + userResponse.getBio()
+                + "\",\"image\":\"" + userResponse.getImage()
+                + "\"}}"
         );
     }
 

--- a/src/test/java/com/study/realworld/user/domain/EmailTest.java
+++ b/src/test/java/com/study/realworld/user/domain/EmailTest.java
@@ -79,7 +79,7 @@ class EmailTest {
 
     @Test
     @DisplayName("equals hashCode 테스트")
-    void emailToStringHashCodeTest() {
+    void emailEqualsHashCodeTest() {
 
         // given
         Email email = new Email("test@test.com");

--- a/src/test/java/com/study/realworld/user/domain/EmailTest.java
+++ b/src/test/java/com/study/realworld/user/domain/EmailTest.java
@@ -91,4 +91,18 @@ class EmailTest {
                 .hasSameHashCodeAs(copyEmail);
     }
 
+    @Test
+    @DisplayName("toString 테스트")
+    void emailToStringTest() {
+
+        // given
+        String input = "test@test.com";
+
+        // when
+        Email email = new Email(input);
+
+        // then
+        assertThat(email.toString()).isEqualTo(input);
+    }
+
 }

--- a/src/test/java/com/study/realworld/user/domain/EmailTest.java
+++ b/src/test/java/com/study/realworld/user/domain/EmailTest.java
@@ -38,7 +38,7 @@ class EmailTest {
 
         // when
         Collection<ConstraintViolation<Email>> constraintViolations
-                = validator.validate(email);
+            = validator.validate(email);
 
         // then
         assertEquals(1, constraintViolations.size());
@@ -54,11 +54,12 @@ class EmailTest {
 
         // when
         Collection<ConstraintViolation<Email>> constraintViolations
-                = validator.validate(email);
+            = validator.validate(email);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("address must be provided.", constraintViolations.iterator().next().getMessage());
+        assertEquals("address must be provided.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test
@@ -70,11 +71,12 @@ class EmailTest {
 
         // when
         Collection<ConstraintViolation<Email>> constraintViolations
-                = validator.validate(email);
+            = validator.validate(email);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("address must be provided.", constraintViolations.iterator().next().getMessage());
+        assertEquals("address must be provided.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test
@@ -87,8 +89,8 @@ class EmailTest {
 
         // when & then
         assertThat(email)
-                .isEqualTo(copyEmail)
-                .hasSameHashCodeAs(copyEmail);
+            .isEqualTo(copyEmail)
+            .hasSameHashCodeAs(copyEmail);
     }
 
     @Test

--- a/src/test/java/com/study/realworld/user/domain/EmailTest.java
+++ b/src/test/java/com/study/realworld/user/domain/EmailTest.java
@@ -1,0 +1,94 @@
+package com.study.realworld.user.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmailTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void beforeEach() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void emailTest() {
+        Email email = new Email();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "test1test.com", "test1@@test.com", "test@test..com"})
+    @DisplayName("이메일 양식이 지켜지지 않은 Email는 validate된다.")
+    void validEmailTest(String input) {
+
+        // given
+        Email email = new Email(input);
+
+        // when
+        Collection<ConstraintViolation<Email>> constraintViolations
+                = validator.validate(email);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("Invalid email address", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("공백인 Email은 validate된다.")
+    void blankEmailTest() {
+
+        // given
+        Email email = new Email("");
+
+        // when
+        Collection<ConstraintViolation<Email>> constraintViolations
+                = validator.validate(email);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("address must be provided.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("null인 Email은 validate된다.")
+    void nullEmailTest() {
+
+        // given
+        Email email = new Email(null);
+
+        // when
+        Collection<ConstraintViolation<Email>> constraintViolations
+                = validator.validate(email);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("address must be provided.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("equals hashCode 테스트")
+    void emailToStringHashCodeTest() {
+
+        // given
+        Email email = new Email("test@test.com");
+        Email copyEmail = new Email("test@test.com");
+
+        // when & then
+        assertThat(email)
+                .isEqualTo(copyEmail)
+                .hasSameHashCodeAs(copyEmail);
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/domain/PasswordTest.java
+++ b/src/test/java/com/study/realworld/user/domain/PasswordTest.java
@@ -46,11 +46,12 @@ class PasswordTest {
 
         // when
         Collection<ConstraintViolation<Password>> constraintViolations
-                = validator.validate(password);
+            = validator.validate(password);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("password length must be between 6 and 20 characters.", constraintViolations.iterator().next().getMessage());
+        assertEquals("password length must be between 6 and 20 characters.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test
@@ -62,11 +63,12 @@ class PasswordTest {
 
         // when
         Collection<ConstraintViolation<Password>> constraintViolations
-                = validator.validate(password);
+            = validator.validate(password);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("password length must be between 6 and 20 characters.", constraintViolations.iterator().next().getMessage());
+        assertEquals("password length must be between 6 and 20 characters.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test
@@ -78,11 +80,12 @@ class PasswordTest {
 
         // when
         Collection<ConstraintViolation<Password>> constraintViolations
-                = validator.validate(password);
+            = validator.validate(password);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("password must be provided.", constraintViolations.iterator().next().getMessage());
+        assertEquals("password must be provided.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test
@@ -94,11 +97,12 @@ class PasswordTest {
 
         // when
         Collection<ConstraintViolation<Password>> constraintViolations
-                = validator.validate(password);
+            = validator.validate(password);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("password must be provided.", constraintViolations.iterator().next().getMessage());
+        assertEquals("password must be provided.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test

--- a/src/test/java/com/study/realworld/user/domain/PasswordTest.java
+++ b/src/test/java/com/study/realworld/user/domain/PasswordTest.java
@@ -1,5 +1,6 @@
 package com.study.realworld.user.domain;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,13 @@ class PasswordTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    private Validator validator;
+
+    @BeforeEach
+    void beforeEach() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
     @Test
     void passwordTest() {
         Password password = new Password();
@@ -34,7 +42,6 @@ class PasswordTest {
     void passwordMaxSizeTest() {
 
         // given
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         Password password = new Password("12345678901234567890123");
 
         // when
@@ -51,7 +58,6 @@ class PasswordTest {
     void passwordMinSizeTest() {
 
         // given
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         Password password = new Password("12345");
 
         // when
@@ -68,7 +74,6 @@ class PasswordTest {
     void passwordNullTest() {
 
         // given
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         Password password = new Password(null);
 
         // when
@@ -85,7 +90,6 @@ class PasswordTest {
     void passwordBlankTest() {
 
         // given
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         Password password = new Password("         ");
 
         // when

--- a/src/test/java/com/study/realworld/user/domain/PasswordTest.java
+++ b/src/test/java/com/study/realworld/user/domain/PasswordTest.java
@@ -1,0 +1,153 @@
+package com.study.realworld.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Collection;
+
+import static com.study.realworld.user.domain.Password.encode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordTest {
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void passwordTest() {
+        Password password = new Password();
+    }
+
+    @Test
+    @DisplayName("패스워드 길이가 20이 넘으면 invalid 되어야 한다.")
+    void passwordMaxSizeTest() {
+
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Password password = new Password("12345678901234567890123");
+
+        // when
+        Collection<ConstraintViolation<Password>> constraintViolations
+                = validator.validate(password);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("password length must be between 6 and 20 characters.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("패스워드 길이가 6이 안되면 invalid 되어야 한다.")
+    void passwordMinSizeTest() {
+
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Password password = new Password("12345");
+
+        // when
+        Collection<ConstraintViolation<Password>> constraintViolations
+                = validator.validate(password);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("password length must be between 6 and 20 characters.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("패스워드에 null이 들어오면 invalid 되어야 한다.")
+    void passwordNullTest() {
+
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Password password = new Password(null);
+
+        // when
+        Collection<ConstraintViolation<Password>> constraintViolations
+                = validator.validate(password);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("password must be provided.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("패스워드에 빈 공백이 들어오면 invalid 되어야 한다.")
+    void passwordBlankTest() {
+
+        // given
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Password password = new Password("         ");
+
+        // when
+        Collection<ConstraintViolation<Password>> constraintViolations
+                = validator.validate(password);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("password must be provided.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("인코더에 패스워드를 넣으면 인코딩된 값이 나와야 한다.")
+    void passwordEncodeTest() {
+
+        // setup
+        when(passwordEncoder.encode(any())).thenReturn("encoded_password");
+
+        // given
+        String input = "password";
+
+        // when
+        Password result = encode(input, passwordEncoder);
+
+        // then
+        assertThat(result.getPassword()).isEqualTo("encoded_password");
+    }
+
+    @Test
+    @DisplayName("입력된 비밀번호가 존재하는 비밀번호와 같으면 true를 반환해야 한다.")
+    void passwordMathckTest() {
+
+        // setup
+        when(passwordEncoder.matches("password", "encoded_password")).thenReturn(true);
+
+        // given
+        Password password = new Password("encoded_password");
+        String input = "password";
+
+        // when
+        boolean result = password.matchPassword("password", passwordEncoder);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("입력된 비밀번호가 존재하는 비밀번호와 다르면 false를 반환해야 한다.")
+    void passwordDismatchTest() {
+
+        // setup
+        when(passwordEncoder.matches("password", "encoded_password")).thenReturn(false);
+
+        // given
+        Password password = new Password("encoded_password");
+        String input = "password";
+
+        // when
+        boolean result = password.matchPassword("password", passwordEncoder);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/domain/PasswordTest.java
+++ b/src/test/java/com/study/realworld/user/domain/PasswordTest.java
@@ -113,10 +113,10 @@ class PasswordTest {
         when(passwordEncoder.encode(any())).thenReturn("encoded_password");
 
         // given
-        String input = "password";
+        Password password = new Password("password");
 
         // when
-        Password result = encode(input, passwordEncoder);
+        Password result = encode(password, passwordEncoder);
 
         // then
         assertThat(result.getPassword()).isEqualTo("encoded_password");

--- a/src/test/java/com/study/realworld/user/domain/UserTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UserTest.java
@@ -25,13 +25,13 @@ class UserTest {
 
         // when
         User user = new User.Builder()
-                .id(id)
-                .username(username)
-                .email(email)
-                .password(password)
-                .bio(bio)
-                .image(image)
-                .build();
+            .id(id)
+            .username(username)
+            .email(email)
+            .password(password)
+            .bio(bio)
+            .image(image)
+            .build();
 
         // then
         assertThat(user.getId()).isEqualTo(id);
@@ -47,13 +47,13 @@ class UserTest {
 
         // given
         User input = new User.Builder()
-                .id(1L)
-                .username(new Username("username"))
-                .email(new Email("email"))
-                .password(new Password("password"))
-                .bio("bio")
-                .image("image")
-                .build();
+            .id(1L)
+            .username(new Username("username"))
+            .email(new Email("email"))
+            .password(new Password("password"))
+            .bio("bio")
+            .image("image")
+            .build();
 
         // when
         User user = new User.Builder(input).build();
@@ -77,8 +77,8 @@ class UserTest {
 
         // when & then
         assertThat(user)
-                .isEqualTo(copyUser)
-                .hasSameHashCodeAs(copyUser);
+            .isEqualTo(copyUser)
+            .hasSameHashCodeAs(copyUser);
     }
 
 }

--- a/src/test/java/com/study/realworld/user/domain/UserTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UserTest.java
@@ -2,10 +2,21 @@ package com.study.realworld.user.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static java.lang.String.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class UserTest {
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Test
     void userTest() {
@@ -65,6 +76,21 @@ class UserTest {
         assertThat(user.getPassword()).isEqualTo(input.getPassword());
         assertThat(user.getBio()).isEqualTo(input.getBio());
         assertThat(user.getImage()).isEqualTo(input.getImage());
+    }
+
+    @Test
+    @DisplayName("encodePassword 메소드가 실행되었을 때 User 객체의 비밀번호가 인코딩되어야 한다.")
+    void userEncodePasswordTest() {
+
+        // setup & given
+        User user = new User.Builder().password(new Password("password")).build();
+        when(passwordEncoder.encode(valueOf(user.getPassword()))).thenReturn("encoded_password");
+
+        // when
+        user.encodePassword(passwordEncoder);
+
+        // then
+        assertThat(user.getPassword().getPassword()).isEqualTo("encoded_password");
     }
 
     @Test

--- a/src/test/java/com/study/realworld/user/domain/UserTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UserTest.java
@@ -43,6 +43,31 @@ class UserTest {
     }
 
     @Test
+    void userBuilderParamUserTest() {
+
+        // given
+        User input = new User.Builder()
+                .id(1L)
+                .username(new Username("username"))
+                .email(new Email("email"))
+                .password(new Password("password"))
+                .bio("bio")
+                .image("image")
+                .build();
+
+        // when
+        User user = new User.Builder(input).build();
+
+        // then
+        assertThat(user.getId()).isEqualTo(input.getId());
+        assertThat(user.getUsername()).isEqualTo(input.getUsername());
+        assertThat(user.getEmail()).isEqualTo(input.getEmail());
+        assertThat(user.getPassword()).isEqualTo(input.getPassword());
+        assertThat(user.getBio()).isEqualTo(input.getBio());
+        assertThat(user.getImage()).isEqualTo(input.getImage());
+    }
+
+    @Test
     @DisplayName("equals hashCode 테스트")
     void userEqualsHashCodeTest() {
 

--- a/src/test/java/com/study/realworld/user/domain/UserTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UserTest.java
@@ -35,7 +35,7 @@ class UserTest {
         String image = "image.jpg";
 
         // when
-        User user = new User.Builder()
+        User user = User.Builder()
             .id(id)
             .username(username)
             .email(email)
@@ -57,7 +57,7 @@ class UserTest {
     void userBuilderParamUserTest() {
 
         // given
-        User input = new User.Builder()
+        User input = User.Builder()
             .id(1L)
             .username(new Username("username"))
             .email(new Email("email"))
@@ -67,7 +67,7 @@ class UserTest {
             .build();
 
         // when
-        User user = new User.Builder(input).build();
+        User user = User.Builder(input).build();
 
         // then
         assertThat(user.getId()).isEqualTo(input.getId());
@@ -83,7 +83,7 @@ class UserTest {
     void userEncodePasswordTest() {
 
         // setup & given
-        User user = new User.Builder().password(new Password("password")).build();
+        User user = User.Builder().password(new Password("password")).build();
         when(passwordEncoder.encode(valueOf(user.getPassword()))).thenReturn("encoded_password");
 
         // when
@@ -98,8 +98,8 @@ class UserTest {
     void userEqualsHashCodeTest() {
 
         // given
-        User user = new User.Builder().email(new Email("test@test.com")).build();
-        User copyUser = new User.Builder().email(new Email("test@test.com")).build();
+        User user = User.Builder().email(new Email("test@test.com")).build();
+        User copyUser = User.Builder().email(new Email("test@test.com")).build();
 
         // when & then
         assertThat(user)

--- a/src/test/java/com/study/realworld/user/domain/UserTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UserTest.java
@@ -1,0 +1,44 @@
+package com.study.realworld.user.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Test
+    void userTest() {
+        User user = new User();
+    }
+
+    @Test
+    void userBuilderTest() {
+
+        // given
+        Long id = 1L;
+        Username username = new Username("username");
+        Email email = new Email("email@email.com");
+        Password password = new Password("password");
+        String bio = "bio";
+        String image = "image.jpg";
+
+        // when
+        User user = new User.Builder()
+                .id(id)
+                .username(username)
+                .email(email)
+                .password(password)
+                .bio(bio)
+                .image(image)
+                .build();
+
+        // then
+        assertThat(user.getId()).isEqualTo(id);
+        assertThat(user.getUsername()).isEqualTo(username);
+        assertThat(user.getEmail()).isEqualTo(email);
+        assertThat(user.getPassword()).isEqualTo(password);
+        assertThat(user.getBio()).isEqualTo(bio);
+        assertThat(user.getImage()).isEqualTo(image);
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/domain/UserTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UserTest.java
@@ -1,5 +1,6 @@
 package com.study.realworld.user.domain;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +40,20 @@ class UserTest {
         assertThat(user.getPassword()).isEqualTo(password);
         assertThat(user.getBio()).isEqualTo(bio);
         assertThat(user.getImage()).isEqualTo(image);
+    }
+
+    @Test
+    @DisplayName("equals hashCode 테스트")
+    void userEqualsHashCodeTest() {
+
+        // given
+        User user = new User.Builder().email(new Email("test@test.com")).build();
+        User copyUser = new User.Builder().email(new Email("test@test.com")).build();
+
+        // when & then
+        assertThat(user)
+                .isEqualTo(copyUser)
+                .hasSameHashCodeAs(copyUser);
     }
 
 }

--- a/src/test/java/com/study/realworld/user/domain/UsernameTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UsernameTest.java
@@ -1,0 +1,140 @@
+package com.study.realworld.user.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UsernameTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void beforeEach() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void usernameTest() {
+        Username username = new Username();
+    }
+
+    @Test
+    @DisplayName("유저 네임은 null이 들어오면 invalid되어야 한다.")
+    void usernameNullTest() {
+
+        // given
+        Username username = new Username(null);
+
+        // when
+        Collection<ConstraintViolation<Username>> constraintViolations
+                = validator.validate(username);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("username must be provided.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("유저 네임은 빈칸이 들어오면 invalid되어야 한다.")
+    void usernameNothingTest() {
+
+        // given
+        Username username = new Username("");
+
+        // when
+        Collection<ConstraintViolation<Username>> constraintViolations
+                = validator.validate(username);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("username must be provided.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("유저 네임은 공백이 들어오면 invalid되어야 한다.")
+    void usernameBlankTest() {
+
+        // given
+        Username username = new Username(" ");
+
+        // when
+        Collection<ConstraintViolation<Username>> constraintViolations
+                = validator.validate(username);
+
+        // then
+        assertEquals(2, constraintViolations.size());
+    }
+
+    @Test
+    @DisplayName("유저네임이 20글자가 넘어가면 invalid되어야 한다.")
+    void usernameMaxSizeTest() {
+
+        // given
+        Username username = new Username("123456789012345678901");
+
+        // when
+        Collection<ConstraintViolation<Username>> constraintViolations
+                = validator.validate(username);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("username length must be less than 20 characters.", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("유저네임은 한글, 숫자, 영어만 들어갈 수 있다.")
+    void usernameValidTest() {
+
+        // given
+        Username username = new Username("123가믜힣abcABC");
+
+        // when
+        Collection<ConstraintViolation<Username>> constraintViolations
+                = validator.validate(username);
+
+        // then
+        assertEquals(0, constraintViolations.size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"테스트1#", "@test", "test."})
+    @DisplayName("유저네임에 한글, 숫자, 영어 말고 다른 값이 들어오면 invalid되어야한다.")
+    void usernameInvalidTest(String input) {
+
+        // given
+        Username username = new Username(input);
+
+        // when
+        Collection<ConstraintViolation<Username>> constraintViolations
+                = validator.validate(username);
+
+        // then
+        assertEquals(1, constraintViolations.size());
+        assertEquals("Invalid username name", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    @DisplayName("equals hashCode 테스트")
+    void usernameToStringHashCodeTest() {
+
+        // given
+        Username username = new Username("test@test.com");
+        Username copyUsername = new Username("test@test.com");
+
+        // when & then
+        assertThat(username)
+                .isEqualTo(copyUsername)
+                .hasSameHashCodeAs(copyUsername);
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/domain/UsernameTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UsernameTest.java
@@ -125,7 +125,7 @@ class UsernameTest {
 
     @Test
     @DisplayName("equals hashCode 테스트")
-    void usernameToStringHashCodeTest() {
+    void usernameEqualsHashCodeTest() {
 
         // given
         Username username = new Username("test@test.com");

--- a/src/test/java/com/study/realworld/user/domain/UsernameTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UsernameTest.java
@@ -137,4 +137,18 @@ class UsernameTest {
                 .hasSameHashCodeAs(copyUsername);
     }
 
+    @Test
+    @DisplayName("toString 테스트")
+    void usernameToStringTest() {
+
+        // given
+        String input = "username";
+
+        // when
+        Username username = new Username(input);
+
+        // then
+        assertThat(username.toString()).isEqualTo(input);
+    }
+
 }

--- a/src/test/java/com/study/realworld/user/domain/UsernameTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UsernameTest.java
@@ -37,11 +37,12 @@ class UsernameTest {
 
         // when
         Collection<ConstraintViolation<Username>> constraintViolations
-                = validator.validate(username);
+            = validator.validate(username);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("username must be provided.", constraintViolations.iterator().next().getMessage());
+        assertEquals("username must be provided.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test
@@ -53,11 +54,12 @@ class UsernameTest {
 
         // when
         Collection<ConstraintViolation<Username>> constraintViolations
-                = validator.validate(username);
+            = validator.validate(username);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("username must be provided.", constraintViolations.iterator().next().getMessage());
+        assertEquals("username must be provided.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test
@@ -69,7 +71,7 @@ class UsernameTest {
 
         // when
         Collection<ConstraintViolation<Username>> constraintViolations
-                = validator.validate(username);
+            = validator.validate(username);
 
         // then
         assertEquals(2, constraintViolations.size());
@@ -84,11 +86,12 @@ class UsernameTest {
 
         // when
         Collection<ConstraintViolation<Username>> constraintViolations
-                = validator.validate(username);
+            = validator.validate(username);
 
         // then
         assertEquals(1, constraintViolations.size());
-        assertEquals("username length must be less than 20 characters.", constraintViolations.iterator().next().getMessage());
+        assertEquals("username length must be less than 20 characters.",
+            constraintViolations.iterator().next().getMessage());
     }
 
     @Test
@@ -100,7 +103,7 @@ class UsernameTest {
 
         // when
         Collection<ConstraintViolation<Username>> constraintViolations
-                = validator.validate(username);
+            = validator.validate(username);
 
         // then
         assertEquals(0, constraintViolations.size());
@@ -116,7 +119,7 @@ class UsernameTest {
 
         // when
         Collection<ConstraintViolation<Username>> constraintViolations
-                = validator.validate(username);
+            = validator.validate(username);
 
         // then
         assertEquals(1, constraintViolations.size());
@@ -133,8 +136,8 @@ class UsernameTest {
 
         // when & then
         assertThat(username)
-                .isEqualTo(copyUsername)
-                .hasSameHashCodeAs(copyUsername);
+            .isEqualTo(copyUsername)
+            .hasSameHashCodeAs(copyUsername);
     }
 
     @Test

--- a/src/test/java/com/study/realworld/user/service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/service/UserServiceTest.java
@@ -1,4 +1,4 @@
-package com.study.realworld.user.Service;
+package com.study.realworld.user.service;
 
 import com.study.realworld.user.domain.*;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## Issue: #1

## 작업 내용
- User 도메인 구현 / data jpa
- 회원가입 기능 구현
- security 추가
- password encoding 구현

## 생성/변경 로직
- POST "/api/users" 에 사용되는 도메인에 대한 설계 및 validate 테스트 진행
- join 요청 시 username, email이 동일한 사람이 이미 있을 경우 exception 처리 > 임시로 RuntimeException 처리
- Jackson을 통한 json type binding

## 개인 코멘트
- 이왕 하는김에 테스트 커버리지를 신경쓰다보니 어느 지점부터는 실패 케이스 작성을 위한 테스트 코드라기보다는 커버리지 작성을 위한 테스트 코드가 되는 것 같아 최대한 실패케이스를 만드는 방향으로 의식하면서 진행했습니다

- 개인적으로 VO로 구현을 하려고 노력(?) 했던거 같네요 :)
- db 테이블 내에는 물론 created_at, updated_ad, deleted_at이 있긴하지만 BaseEntity에 대한 생각을 조금 더 하고 구현을 하고 싶어서 미뤘습니다 😢 
- Response Entity에 대해서 ApiResult 클래스를 만들고 싶었는데 반환되는 json이 한정되어있던터라 어떻게 json 테스트가 진행되는지 몰라 내버려뒀습니다 😂
