### PR TITLE
[jinyoungchoi95-issue16] 현재 유저 정보 반환 및 업데이트 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -37,33 +37,26 @@ public class UserController {
     @PostMapping("/users")
     public ResponseEntity<UserResponse> join(@RequestBody UserJoinRequest request) {
         User user = userService.join(request.toUser());
-        return ResponseEntity.ok()
-            .body(fromUserAndToken(user, jwtService.createToken(user)));
+        return ResponseEntity.ok().body(fromUserAndToken(user, jwtService.createToken(user)));
     }
 
     @PostMapping("/users/login")
     public ResponseEntity<UserResponse> login(@RequestBody UserLoginRequest request) {
-        User user = userService
-            .login(new Email(request.getEmail()), new Password(request.getPassword()));
-        return ResponseEntity.ok()
-            .body(fromUserAndToken(user, jwtService.createToken(user)));
+        User user = userService.login(new Email(request.getEmail()), new Password(request.getPassword()));
+        return ResponseEntity.ok().body(fromUserAndToken(user, jwtService.createToken(user)));
     }
 
     @GetMapping("/user")
     public ResponseEntity<UserResponse> getCurrentUser(@AuthenticationPrincipal Long loginId) {
-        User user = userService
-            .findById(loginId).orElseThrow(RuntimeException::new);   // 임시
-        return ResponseEntity.ok()
-            .body(fromUserAndToken(user, getTokenByContextHolder()));
+        User user = userService.findById(loginId).orElseThrow(RuntimeException::new);   // 임시
+        return ResponseEntity.ok().body(fromUserAndToken(user, getTokenByContextHolder()));
     }
 
     @PutMapping("/user")
     public ResponseEntity<UserResponse> update(@RequestBody UserUpdateRequest request,
         @AuthenticationPrincipal Long loginId) {
-        User user = userService
-            .update(request.toUserUpdateModel(), loginId);
-        return ResponseEntity.ok()
-            .body(fromUserAndToken(user, getTokenByContextHolder()));
+        User user = userService.update(request.toUserUpdateModel(), loginId);
+        return ResponseEntity.ok().body(fromUserAndToken(user, getTokenByContextHolder()));
     }
 
     private String getTokenByContextHolder() {

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -5,6 +5,7 @@ import static com.study.realworld.user.controller.response.UserResponse.fromUser
 import com.study.realworld.security.JwtService;
 import com.study.realworld.user.controller.request.UserJoinRequest;
 import com.study.realworld.user.controller.request.UserLoginRequest;
+import com.study.realworld.user.controller.request.UserUpdateRequest;
 import com.study.realworld.user.controller.response.UserResponse;
 import com.study.realworld.user.domain.Email;
 import com.study.realworld.user.domain.Password;
@@ -15,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -51,6 +53,17 @@ public class UserController {
     public ResponseEntity<UserResponse> getCurrentUser(@AuthenticationPrincipal Long loginId) {
         User user = userService
             .findById(loginId).orElseThrow(RuntimeException::new);   // 임시
+        String token = SecurityContextHolder.getContext().getAuthentication().getCredentials()
+            .toString();
+        return ResponseEntity.ok()
+            .body(fromUserAndToken(user, token));
+    }
+
+    @PutMapping("/user")
+    public ResponseEntity<UserResponse> update(@RequestBody UserUpdateRequest request,
+        @AuthenticationPrincipal Long loginId) {
+        User user = userService
+            .update(request.toUserUpdateModel(), loginId);
         String token = SecurityContextHolder.getContext().getAuthentication().getCredentials()
             .toString();
         return ResponseEntity.ok()

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -53,10 +53,8 @@ public class UserController {
     public ResponseEntity<UserResponse> getCurrentUser(@AuthenticationPrincipal Long loginId) {
         User user = userService
             .findById(loginId).orElseThrow(RuntimeException::new);   // 임시
-        String token = SecurityContextHolder.getContext().getAuthentication().getCredentials()
-            .toString();
         return ResponseEntity.ok()
-            .body(fromUserAndToken(user, token));
+            .body(fromUserAndToken(user, getTokenByContextHolder()));
     }
 
     @PutMapping("/user")
@@ -64,10 +62,12 @@ public class UserController {
         @AuthenticationPrincipal Long loginId) {
         User user = userService
             .update(request.toUserUpdateModel(), loginId);
-        String token = SecurityContextHolder.getContext().getAuthentication().getCredentials()
-            .toString();
         return ResponseEntity.ok()
-            .body(fromUserAndToken(user, token));
+            .body(fromUserAndToken(user, getTokenByContextHolder()));
+    }
+
+    private String getTokenByContextHolder() {
+        return SecurityContextHolder.getContext().getAuthentication().getCredentials().toString();
     }
 
 }

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -11,6 +11,9 @@ import com.study.realworld.user.domain.Password;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,6 +45,16 @@ public class UserController {
             .login(new Email(request.getEmail()), new Password(request.getPassword()));
         return ResponseEntity.ok()
             .body(fromUserAndToken(user, jwtService.createToken(user)));
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<UserResponse> getCurrentUser(@AuthenticationPrincipal Long loginId) {
+        User user = userService
+            .findById(loginId).orElseThrow(RuntimeException::new);   // 임시
+        String token = SecurityContextHolder.getContext().getAuthentication().getCredentials()
+            .toString();
+        return ResponseEntity.ok()
+            .body(fromUserAndToken(user, token));
     }
 
 }

--- a/src/main/java/com/study/realworld/user/controller/request/UserUpdateRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserUpdateRequest.java
@@ -53,9 +53,9 @@ public class UserUpdateRequest {
 
     public UserUpdateModel toUserUpdateModel() {
         return new UserUpdateModel(
-            Optional.ofNullable(getUsername()).map(Username::new).orElse(null),
-            Optional.ofNullable(getEmail()).map(Email::new).orElse(null),
-            Optional.ofNullable(getPassword()).map(Password::new).orElse(null),
+            new Username(getUsername()),
+            new Email(getEmail()),
+            new Password(getPassword()),
             getBio(),
             getImage()
         );

--- a/src/main/java/com/study/realworld/user/controller/request/UserUpdateRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserUpdateRequest.java
@@ -1,0 +1,64 @@
+package com.study.realworld.user.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.Password;
+import com.study.realworld.user.domain.Username;
+import com.study.realworld.user.service.model.UserUpdateModel;
+import java.util.Optional;
+
+@JsonTypeName(value = "user")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+public class UserUpdateRequest {
+
+    @JsonProperty("username")
+    private String username;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("password")
+    private String password;
+
+    @JsonProperty("bio")
+    private String bio;
+
+    @JsonProperty("image")
+    private String image;
+
+    protected UserUpdateRequest() {
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public UserUpdateModel toUserUpdateModel() {
+        return new UserUpdateModel(
+            Optional.ofNullable(getUsername()).map(Username::new).orElse(null),
+            Optional.ofNullable(getEmail()).map(Email::new).orElse(null),
+            Optional.ofNullable(getPassword()).map(Password::new).orElse(null),
+            getBio(),
+            getImage()
+        );
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
+++ b/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
@@ -61,8 +61,8 @@ public class UserResponse {
         return new UserResponse(
             valueOf(user.getUsername()),
             valueOf(user.getEmail()),
-            valueOf(user.getBio()),
-            valueOf(user.getImage()),
+            user.getBio(),
+            user.getImage(),
             valueOf(accessToken)
         );
     }

--- a/src/main/java/com/study/realworld/user/domain/Email.java
+++ b/src/main/java/com/study/realworld/user/domain/Email.java
@@ -1,15 +1,16 @@
 package com.study.realworld.user.domain;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.regex.Pattern.matches;
+
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import javax.validation.constraints.NotEmpty;
+import org.apache.commons.lang3.StringUtils;
 
 @Embeddable
 public class Email {
 
-    @NotEmpty(message = "address must be provided.")
-    @javax.validation.constraints.Email(message = "Invalid email address")
     @Column(name = "email", length = 50, unique = true, nullable = false)
     private String address;
 
@@ -17,7 +18,18 @@ public class Email {
     }
 
     public Email(String address) {
+        checkEmail(address);
+
         this.address = address;
+    }
+
+    private static void checkEmail(String address) {
+        checkArgument(StringUtils.isNotBlank(address), "address must be provided.");
+        checkArgument(checkEmailPattern(address), "address must be provided by limited pattern like 'xxx@xxx.xxx'.");
+    }
+
+    private static boolean checkEmailPattern(String address) {
+        return matches("[\\w~\\-.+]+@[\\w~\\-]+(\\.[\\w~\\-]+)+", address);
     }
 
     @Override

--- a/src/main/java/com/study/realworld/user/domain/Password.java
+++ b/src/main/java/com/study/realworld/user/domain/Password.java
@@ -4,8 +4,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 

--- a/src/main/java/com/study/realworld/user/domain/Password.java
+++ b/src/main/java/com/study/realworld/user/domain/Password.java
@@ -1,17 +1,17 @@
 package com.study.realworld.user.domain;
 
-import org.springframework.security.crypto.password.PasswordEncoder;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Embeddable
 public class Password {
 
-    @NotBlank(message = "password must be provided.")
-    @Size(min = 6, max = 20, message = "password length must be between 6 and 20 characters.")
     @Column(name = "password", nullable = false)
     private String password;
 
@@ -19,7 +19,17 @@ public class Password {
     }
 
     public Password(String password) {
+        checkPassword(password);
+
         this.password = password;
+    }
+
+    private static void checkPassword(String password) {
+        checkArgument(StringUtils.isNotBlank(password), "password must be provided.");
+        checkArgument(
+            password.length() >= 6 && password.length() <= 20,
+            "password length must be between 6 and 20 characters."
+        );
     }
 
     public String getPassword() {
@@ -32,7 +42,7 @@ public class Password {
 
     public void matchPassword(Password rawPassword, PasswordEncoder passwordEncoder) {
         if (!passwordEncoder.matches(rawPassword.password, this.password)) {
-            throw new RuntimeException("비밀번호가 다릅니다.");
+            throw new RuntimeException("password is different from old password.");
         }
     }
 

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -70,6 +70,26 @@ public class User {
         return image;
     }
 
+    public void changeUsername(Username username) {
+        this.username = username;
+    }
+
+    public void changeEmail(Email email) {
+        this.email = email;
+    }
+
+    public void changePassword(Password password) {
+        this.password = password;
+    }
+
+    public void changeBio(String bio) {
+        this.bio = bio;
+    }
+
+    public void changeImage(String image) {
+        this.image = image;
+    }
+
     public void encodePassword(PasswordEncoder passwordEncoder) {
         this.password = Password.encode(this.password, passwordEncoder);
     }

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -36,8 +36,7 @@ public class User {
     protected User() {
     }
 
-    private User(Long id, Username username, Email email, Password password, String bio,
-        String image) {
+    private User(Long id, Username username, Email email, Password password, String bio, String image) {
         this.id = id;
         this.username = username;
         this.email = email;

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -77,8 +77,8 @@ public class User {
         this.email = email;
     }
 
-    public void changePassword(Password password) {
-        this.password = password;
+    public void changePassword(Password password, PasswordEncoder passwordEncoder) {
+        this.password = Password.encode(password, passwordEncoder);
     }
 
     public void changeBio(String bio) {

--- a/src/main/java/com/study/realworld/user/domain/Username.java
+++ b/src/main/java/com/study/realworld/user/domain/Username.java
@@ -1,18 +1,19 @@
 package com.study.realworld.user.domain;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.regex.Pattern.matches;
+
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import org.apache.commons.lang3.StringUtils;
 
 @Embeddable
 public class Username {
 
-    @NotBlank(message = "username must be provided.")
-    @Size(max = 20, message = "username length must be less than 20 characters.")
-    @Pattern(regexp = "^[0-9a-zA-Z가-힣]*$", message = "Invalid username name")
     @Column(name = "username", length = 20, unique = true, nullable = false)
     private String name;
 
@@ -20,7 +21,19 @@ public class Username {
     }
 
     public Username(String name) {
+        checkUsername(name);
+
         this.name = name;
+    }
+
+    private static void checkUsername(String name) {
+        checkArgument(StringUtils.isNotBlank(name), "username must be provided.");
+        checkArgument(name.length() <= 20, "username length must be less then 20 characters.");
+        checkArgument(checkUsernamePattern(name), "usernmae must be provided by limited pattern.");
+    }
+
+    private static boolean checkUsernamePattern(String name) {
+        return matches("^[0-9a-zA-Z가-힣]*$", name);
     }
 
     @Override

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -51,33 +51,24 @@ public class UserService {
         User user = userRepository.findById(userId).orElseThrow(RuntimeException::new);
 
         updateUser.getUsername()
-            .filter(username -> !user.getUsername().equals(username))
             .ifPresent(
                 username -> {
                     checkDuplicatedByUsername(username);
                     user.changeUsername(username);
                 });
         updateUser.getEmail()
-            .filter(email -> !user.getEmail().equals(email))
             .ifPresent(
                 email -> {
                     checkDuplicatedByEmail(email);
                     user.changeEmail(email);
                 });
         updateUser.getPassword()
-            .filter(
-                password -> !passwordEncoder
-                    .matches(password.getPassword(), user.getPassword().getPassword()))
             .ifPresent(
                 password -> {
                     user.changePassword(Password.encode(password, passwordEncoder));
                 });
-        updateUser.getBio()
-            .filter(bio -> !user.getBio().equals(bio))
-            .ifPresent(user::changeBio);
-        updateUser.getImage()
-            .filter(image -> !user.getImage().equals(image))
-            .ifPresent(user::changeImage);
+        updateUser.getBio().ifPresent(user::changeBio);
+        updateUser.getImage().ifPresent(user::changeImage);
 
         return user;
     }

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -63,10 +63,7 @@ public class UserService {
                     user.changeEmail(email);
                 });
         updateUser.getPassword()
-            .ifPresent(
-                password -> {
-                    user.changePassword(Password.encode(password, passwordEncoder));
-                });
+            .ifPresent(password -> user.changePassword(Password.encode(password, passwordEncoder)));
         updateUser.getBio().ifPresent(user::changeBio);
         updateUser.getImage().ifPresent(user::changeImage);
 
@@ -74,15 +71,13 @@ public class UserService {
     }
 
     private void checkDuplicatedByUsername(@Valid Username username) {
-        findByUsername(username)
-            .ifPresent(param -> {
+        findByUsername(username).ifPresent(param -> {
                 throw new RuntimeException("already user username");
             });
     }
 
     private void checkDuplicatedByEmail(@Valid Email email) {
-        findByEmail(email)
-            .ifPresent(param -> {
+        findByEmail(email).ifPresent(param -> {
                 throw new RuntimeException("already user email");
             });
     }

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -50,14 +50,8 @@ public class UserService {
     public User update(UserUpdateModel updateUser, Long userId) {
         User user = userRepository.findById(userId).orElseThrow(RuntimeException::new);
 
-        updateUser.getUsername().ifPresent(username -> {
-            checkDuplicatedByUsername(username);
-            user.changeUsername(username);
-        });
-        updateUser.getEmail().ifPresent(email -> {
-            checkDuplicatedByEmail(email);
-            user.changeEmail(email);
-        });
+        updateUser.getUsername().ifPresent(username -> checkDuplicatedUsernameAndChangeUsername(user, username));
+        updateUser.getEmail().ifPresent(email -> checkDuplicatedEmailAndChangeEmail(user, email));
         updateUser.getPassword().ifPresent(password -> user.changePassword(password, passwordEncoder));
         updateUser.getBio().ifPresent(user::changeBio);
         updateUser.getImage().ifPresent(user::changeImage);
@@ -65,13 +59,13 @@ public class UserService {
         return user;
     }
 
-    private void checkDuplicatedByUsername(@Valid Username username) {
+    private void checkDuplicatedByUsername(Username username) {
         findByUsername(username).ifPresent(param -> {
             throw new RuntimeException("already user username");
         });
     }
 
-    private void checkDuplicatedByEmail(@Valid Email email) {
+    private void checkDuplicatedByEmail(Email email) {
         findByEmail(email).ifPresent(param -> {
             throw new RuntimeException("already user email");
         });
@@ -83,6 +77,16 @@ public class UserService {
 
     private Optional<User> findByEmail(Email email) {
         return userRepository.findByEmail(email);
+    }
+
+    private void checkDuplicatedEmailAndChangeEmail(User user, Email email) {
+        checkDuplicatedByEmail(email);
+        user.changeEmail(email);
+    }
+
+    private void checkDuplicatedUsernameAndChangeUsername(User user, Username username) {
+        checkDuplicatedByUsername(username);
+        user.changeUsername(username);
     }
 
 }

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -50,16 +50,14 @@ public class UserService {
     public User update(UserUpdateModel updateUser, Long userId) {
         User user = userRepository.findById(userId).orElseThrow(RuntimeException::new);
 
-        updateUser.getUsername()
-            .ifPresent(username -> {
-                    checkDuplicatedByUsername(username);
-                    user.changeUsername(username);
-                });
-        updateUser.getEmail()
-            .ifPresent(email -> {
-                    checkDuplicatedByEmail(email);
-                    user.changeEmail(email);
-                });
+        updateUser.getUsername().ifPresent(username -> {
+            checkDuplicatedByUsername(username);
+            user.changeUsername(username);
+        });
+        updateUser.getEmail().ifPresent(email -> {
+            checkDuplicatedByEmail(email);
+            user.changeEmail(email);
+        });
         updateUser.getPassword().ifPresent(password -> user.changePassword(password, passwordEncoder));
         updateUser.getBio().ifPresent(user::changeBio);
         updateUser.getImage().ifPresent(user::changeImage);
@@ -69,14 +67,14 @@ public class UserService {
 
     private void checkDuplicatedByUsername(@Valid Username username) {
         findByUsername(username).ifPresent(param -> {
-                throw new RuntimeException("already user username");
-            });
+            throw new RuntimeException("already user username");
+        });
     }
 
     private void checkDuplicatedByEmail(@Valid Email email) {
         findByEmail(email).ifPresent(param -> {
-                throw new RuntimeException("already user email");
-            });
+            throw new RuntimeException("already user email");
+        });
     }
 
     private Optional<User> findByUsername(Username username) {

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -39,6 +39,11 @@ public class UserService {
         return user;
     }
 
+    @Transactional(readOnly = true)
+    public Optional<User> findById(Long userId) {
+        return userRepository.findById(userId);
+    }
+
     private void checkDuplicatedByUsernameOrEmail(Username username, Email email) {
         findByUsername(username)
             .ifPresent(param -> {

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -51,19 +51,16 @@ public class UserService {
         User user = userRepository.findById(userId).orElseThrow(RuntimeException::new);
 
         updateUser.getUsername()
-            .ifPresent(
-                username -> {
+            .ifPresent(username -> {
                     checkDuplicatedByUsername(username);
                     user.changeUsername(username);
                 });
         updateUser.getEmail()
-            .ifPresent(
-                email -> {
+            .ifPresent(email -> {
                     checkDuplicatedByEmail(email);
                     user.changeEmail(email);
                 });
-        updateUser.getPassword()
-            .ifPresent(password -> user.changePassword(Password.encode(password, passwordEncoder)));
+        updateUser.getPassword().ifPresent(password -> user.changePassword(password, passwordEncoder));
         updateUser.getBio().ifPresent(user::changeBio);
         updateUser.getImage().ifPresent(user::changeImage);
 

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -26,7 +26,8 @@ public class UserService {
 
     @Transactional
     public User join(@Valid User user) {
-        checkDuplicatedByUsernameOrEmail(user.getUsername(), user.getEmail());
+        checkDuplicatedByUsername(user.getUsername());
+        checkDuplicatedByEmail(user.getEmail());
 
         user.encodePassword(passwordEncoder);
         return userRepository.save(user);
@@ -44,15 +45,19 @@ public class UserService {
         return userRepository.findById(userId);
     }
 
-    private void checkDuplicatedByUsernameOrEmail(Username username, Email email) {
+    private void checkDuplicatedByUsername(@Valid Username username) {
         findByUsername(username)
             .ifPresent(param -> {
                 throw new RuntimeException("already user username");
             });
+    }
+
+    private void checkDuplicatedByEmail(@Valid Email email) {
         findByEmail(email)
             .ifPresent(param -> {
                 throw new RuntimeException("already user email");
             });
+
     }
 
     private Optional<User> findByUsername(Username username) {

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -70,7 +70,6 @@ public class UserService {
                     .matches(password.getPassword(), user.getPassword().getPassword()))
             .ifPresent(
                 password -> {
-                    validByPassword(password);
                     user.changePassword(Password.encode(password, passwordEncoder));
                 });
         updateUser.getBio()
@@ -81,9 +80,6 @@ public class UserService {
             .ifPresent(user::changeImage);
 
         return user;
-    }
-
-    private void validByPassword(@Valid Password password) {
     }
 
     private void checkDuplicatedByUsername(@Valid Username username) {

--- a/src/main/java/com/study/realworld/user/service/model/UserUpdateModel.java
+++ b/src/main/java/com/study/realworld/user/service/model/UserUpdateModel.java
@@ -13,8 +13,7 @@ public class UserUpdateModel {
     private final String bio;
     private final String image;
 
-    public UserUpdateModel(Username username, Email email, Password password, String bio,
-        String image) {
+    public UserUpdateModel(Username username, Email email, Password password, String bio, String image) {
         this.username = username;
         this.email = email;
         this.password = password;

--- a/src/main/java/com/study/realworld/user/service/model/UserUpdateModel.java
+++ b/src/main/java/com/study/realworld/user/service/model/UserUpdateModel.java
@@ -1,0 +1,45 @@
+package com.study.realworld.user.service.model;
+
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.Password;
+import com.study.realworld.user.domain.Username;
+import java.util.Optional;
+
+public class UserUpdateModel {
+
+    private final Username username;
+    private final Email email;
+    private final Password password;
+    private final String bio;
+    private final String image;
+
+    public UserUpdateModel(Username username, Email email, Password password, String bio,
+        String image) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.bio = bio;
+        this.image = image;
+    }
+
+    public Optional<Username> getUsername() {
+        return Optional.ofNullable(username);
+    }
+
+    public Optional<Email> getEmail() {
+        return Optional.ofNullable(email);
+    }
+
+    public Optional<Password> getPassword() {
+        return Optional.ofNullable(password);
+    }
+
+    public Optional<String> getBio() {
+        return Optional.ofNullable(bio);
+    }
+
+    public Optional<String> getImage() {
+        return Optional.ofNullable(image);
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -35,7 +35,6 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -176,4 +176,48 @@ class UserControllerTest {
         ;
     }
 
+    @Test
+    void getCurrentUserTest() throws Exception {
+
+        // setup
+        User user = User.Builder()
+            .username(new Username("username"))
+            .email(new Email("test@test.com"))
+            .password(new Password("password"))
+            .build();
+        when(userService.findById(any())).thenReturn(Optional.ofNullable(user));
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthentication(1L, "token"));
+
+        // given
+        final String URL = "/api/user";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get(URL)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+            .andExpect(jsonPath("$.user.username", is("username")))
+            .andExpect(jsonPath("$.user.email", is("test@test.com")))
+            .andExpect(jsonPath("$.user.bio", is("null")))
+            .andExpect(jsonPath("$.user.image", is("null")))
+            .andExpect(jsonPath("$.user.token", is("token")))
+            .andDo(document("user-get-current",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                responseFields(
+                    fieldWithPath("user.email").type(JsonFieldType.STRING).description("이메일"),
+                    fieldWithPath("user.token").type(JsonFieldType.STRING).description("로그인 토큰"),
+                    fieldWithPath("user.username").type(JsonFieldType.STRING).description("유저이름"),
+                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio"),
+                    fieldWithPath("user.image").type(JsonFieldType.STRING).description("이미지")
+                )
+            ))
+        ;
+    }
+
 }

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.study.realworld.user.controller;
 import static com.study.realworld.user.controller.ApiDocumentUtils.getDocumentRequest;
 import static com.study.realworld.user.controller.ApiDocumentUtils.getDocumentResponse;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -96,8 +97,8 @@ class UserControllerTest {
 
             .andExpect(jsonPath("$.user.username", is("username")))
             .andExpect(jsonPath("$.user.email", is("test@test.com")))
-            .andExpect(jsonPath("$.user.bio", is("null")))
-            .andExpect(jsonPath("$.user.image", is("null")))
+            .andExpect(jsonPath("$.user.bio", is(nullValue())))
+            .andExpect(jsonPath("$.user.image", is(nullValue())))
             .andExpect(jsonPath("$.user.token", is("token")))
             .andDo(document("user-join",
                 getDocumentRequest(),
@@ -115,8 +116,10 @@ class UserControllerTest {
                     fieldWithPath("user.email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("user.token").type(JsonFieldType.STRING).description("로그인 토큰"),
                     fieldWithPath("user.username").type(JsonFieldType.STRING).description("유저이름"),
-                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio"),
+                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio")
+                        .optional(),
                     fieldWithPath("user.image").type(JsonFieldType.STRING).description("이미지")
+                        .optional()
                 )
             ))
         ;
@@ -155,8 +158,8 @@ class UserControllerTest {
 
             .andExpect(jsonPath("$.user.username", is("username")))
             .andExpect(jsonPath("$.user.email", is("test@test.com")))
-            .andExpect(jsonPath("$.user.bio", is("null")))
-            .andExpect(jsonPath("$.user.image", is("null")))
+            .andExpect(jsonPath("$.user.bio", is(nullValue())))
+            .andExpect(jsonPath("$.user.image", is(nullValue())))
             .andExpect(jsonPath("$.user.token", is("token")))
             .andDo(document("user-login",
                 getDocumentRequest(),
@@ -169,8 +172,10 @@ class UserControllerTest {
                     fieldWithPath("user.email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("user.token").type(JsonFieldType.STRING).description("로그인 토큰"),
                     fieldWithPath("user.username").type(JsonFieldType.STRING).description("유저이름"),
-                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio"),
+                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio")
+                        .optional(),
                     fieldWithPath("user.image").type(JsonFieldType.STRING).description("이미지")
+                        .optional()
                 )
             ))
         ;
@@ -203,8 +208,8 @@ class UserControllerTest {
 
             .andExpect(jsonPath("$.user.username", is("username")))
             .andExpect(jsonPath("$.user.email", is("test@test.com")))
-            .andExpect(jsonPath("$.user.bio", is("null")))
-            .andExpect(jsonPath("$.user.image", is("null")))
+            .andExpect(jsonPath("$.user.bio", is(nullValue())))
+            .andExpect(jsonPath("$.user.image", is(nullValue())))
             .andExpect(jsonPath("$.user.token", is("token")))
             .andDo(document("user-get-current",
                 getDocumentRequest(),
@@ -213,8 +218,10 @@ class UserControllerTest {
                     fieldWithPath("user.email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("user.token").type(JsonFieldType.STRING).description("로그인 토큰"),
                     fieldWithPath("user.username").type(JsonFieldType.STRING).description("유저이름"),
-                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio"),
+                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio")
+                        .optional(),
                     fieldWithPath("user.image").type(JsonFieldType.STRING).description("이미지")
+                        .optional()
                 )
             ))
         ;
@@ -276,8 +283,10 @@ class UserControllerTest {
                     fieldWithPath("user.email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("user.token").type(JsonFieldType.STRING).description("로그인 토큰"),
                     fieldWithPath("user.username").type(JsonFieldType.STRING).description("유저이름"),
-                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio"),
+                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio")
+                        .optional(),
                     fieldWithPath("user.image").type(JsonFieldType.STRING).description("이미지")
+                        .optional()
                 )
             ))
         ;

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -58,6 +58,7 @@ class UserControllerTest {
 
     @BeforeEach
     void beforeEach(RestDocumentationContextProvider restDocumentationContextProvider) {
+        SecurityContextHolder.clearContext();
         mockMvc = MockMvcBuilders.standaloneSetup(userController)
             .apply(documentationConfiguration(restDocumentationContextProvider))
             .alwaysExpect(status().isOk())

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -194,7 +194,7 @@ class UserControllerTest {
             .email(new Email("test@test.com"))
             .password(new Password("password"))
             .build();
-        when(userService.findById(1L)).thenReturn(Optional.ofNullable(user));
+        when(userService.findById(any())).thenReturn(Optional.ofNullable(user));
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthentication(1L, "token"));
 
         // given

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -10,18 +10,21 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.study.realworld.security.JwtAuthentication;
 import com.study.realworld.security.JwtService;
 import com.study.realworld.user.domain.Email;
 import com.study.realworld.user.domain.Password;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.Username;
 import com.study.realworld.user.service.UserService;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +35,8 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -100,7 +105,11 @@ class UserControllerTest {
                 requestFields(
                     fieldWithPath("user.username").type(JsonFieldType.STRING).description("유저이름"),
                     fieldWithPath("user.email").type(JsonFieldType.STRING).description("이메일"),
-                    fieldWithPath("user.password").type(JsonFieldType.STRING).description("패스워드")
+                    fieldWithPath("user.password").type(JsonFieldType.STRING).description("패스워드"),
+                    fieldWithPath("user.bio").type(JsonFieldType.STRING).description("bio")
+                        .optional(),
+                    fieldWithPath("user.image").type(JsonFieldType.STRING).description("이미지")
+                        .optional()
                 ),
                 responseFields(
                     fieldWithPath("user.email").type(JsonFieldType.STRING).description("이메일"),

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -26,6 +26,7 @@ import com.study.realworld.user.domain.Password;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.Username;
 import com.study.realworld.user.service.UserService;
+import java.security.Principal;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,8 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -191,14 +194,16 @@ class UserControllerTest {
             .email(new Email("test@test.com"))
             .password(new Password("password"))
             .build();
-        when(userService.findById(any())).thenReturn(Optional.ofNullable(user));
+        when(userService.findById(1L)).thenReturn(Optional.ofNullable(user));
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthentication(1L, "token"));
 
         // given
         final String URL = "/api/user";
 
         // when
+        AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(1L, "1q2w3e4r");
         ResultActions resultActions = mockMvc.perform(get(URL)
+            .principal(authenticationToken)
             .contentType(MediaType.APPLICATION_JSON))
             .andDo(print());
 

--- a/src/test/java/com/study/realworld/user/domain/EmailTest.java
+++ b/src/test/java/com/study/realworld/user/domain/EmailTest.java
@@ -1,6 +1,7 @@
 package com.study.realworld.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collection;
@@ -15,50 +16,31 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class EmailTest {
 
-    private Validator validator;
-
-    @BeforeEach
-    void beforeEach() {
-        validator = Validation.buildDefaultValidatorFactory().getValidator();
-    }
-
     @Test
     void emailTest() {
         Email email = new Email();
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {" ", "test1test.com", "test1@@test.com", "test@test..com"})
+    @ValueSource(strings = {"test1test.com", "test1@@test.com", "test@test..com"})
     @DisplayName("이메일 양식이 지켜지지 않은 Email는 validate된다.")
     void validEmailTest(String input) {
 
-        // given
-        Email email = new Email(input);
-
-        // when
-        Collection<ConstraintViolation<Email>> constraintViolations
-            = validator.validate(email);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("Invalid email address", constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Email(input))
+            .withMessageMatching("address must be provided by limited pattern like 'xxx@xxx.xxx'.");
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "   "})
     @DisplayName("공백인 Email은 validate된다.")
-    void blankEmailTest() {
+    void blankEmailTest(String input) {
 
-        // given
-        Email email = new Email("");
-
-        // when
-        Collection<ConstraintViolation<Email>> constraintViolations
-            = validator.validate(email);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("address must be provided.",
-            constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Email(input))
+            .withMessageMatching("address must be provided.");
     }
 
     @Test
@@ -66,16 +48,13 @@ class EmailTest {
     void nullEmailTest() {
 
         // given
-        Email email = new Email(null);
+        String input = null;
 
-        // when
-        Collection<ConstraintViolation<Email>> constraintViolations
-            = validator.validate(email);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("address must be provided.",
-            constraintViolations.iterator().next().getMessage());
+        // when & given
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Email(input))
+            .withMessageMatching("address must be provided.");
     }
 
     @Test

--- a/src/test/java/com/study/realworld/user/domain/PasswordTest.java
+++ b/src/test/java/com/study/realworld/user/domain/PasswordTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,13 +28,6 @@ class PasswordTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    private Validator validator;
-
-    @BeforeEach
-    void beforeEach() {
-        validator = Validation.buildDefaultValidatorFactory().getValidator();
-    }
-
     @Test
     void passwordTest() {
         Password password = new Password();
@@ -42,68 +37,41 @@ class PasswordTest {
     @DisplayName("패스워드 길이가 20이 넘으면 invalid 되어야 한다.")
     void passwordMaxSizeTest() {
 
-        // given
-        Password password = new Password("12345678901234567890123");
-
-        // when
-        Collection<ConstraintViolation<Password>> constraintViolations
-            = validator.validate(password);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("password length must be between 6 and 20 characters.",
-            constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Password("12345678901234567890123"))
+            .withMessageMatching("password length must be between 6 and 20 characters.");
     }
 
     @Test
     @DisplayName("패스워드 길이가 6이 안되면 invalid 되어야 한다.")
     void passwordMinSizeTest() {
 
-        // given
-        Password password = new Password("12345");
-
-        // when
-        Collection<ConstraintViolation<Password>> constraintViolations
-            = validator.validate(password);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("password length must be between 6 and 20 characters.",
-            constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Password("12345"))
+            .withMessageMatching("password length must be between 6 and 20 characters.");
     }
 
     @Test
     @DisplayName("패스워드에 null이 들어오면 invalid 되어야 한다.")
     void passwordNullTest() {
 
-        // given
-        Password password = new Password(null);
-
-        // when
-        Collection<ConstraintViolation<Password>> constraintViolations
-            = validator.validate(password);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("password must be provided.",
-            constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Password(null))
+            .withMessageMatching("password must be provided.");
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "    "})
     @DisplayName("패스워드에 빈 공백이 들어오면 invalid 되어야 한다.")
-    void passwordBlankTest() {
+    void passwordBlankTest(String input) {
 
-        // given
-        Password password = new Password("         ");
-
-        // when
-        Collection<ConstraintViolation<Password>> constraintViolations
-            = validator.validate(password);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("password must be provided.",
-            constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Password(input))
+            .withMessageMatching("password must be provided.");
     }
 
     @Test
@@ -152,7 +120,7 @@ class PasswordTest {
         // when & then
         assertThatExceptionOfType(RuntimeException.class)
             .isThrownBy(() -> password.matchPassword(new Password("password"), passwordEncoder))
-            .withMessageMatching("비밀번호가 다릅니다.");
+            .withMessageMatching("password is different from old password.");
     }
 
 }

--- a/src/test/java/com/study/realworld/user/domain/UserTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UserTest.java
@@ -123,7 +123,7 @@ class UserTest {
         // when & then
         assertThatExceptionOfType(RuntimeException.class)
             .isThrownBy(() -> user.login(password, passwordEncoder))
-            .withMessageMatching("비밀번호가 다릅니다.");
+            .withMessageMatching("password is different from old password.");
     }
 
     @Test

--- a/src/test/java/com/study/realworld/user/domain/UserTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UserTest.java
@@ -60,7 +60,7 @@ class UserTest {
         User input = User.Builder()
             .id(1L)
             .username(new Username("username"))
-            .email(new Email("email"))
+            .email(new Email("test@test.com"))
             .password(new Password("password"))
             .bio("bio")
             .image("image")

--- a/src/test/java/com/study/realworld/user/domain/UsernameTest.java
+++ b/src/test/java/com/study/realworld/user/domain/UsernameTest.java
@@ -1,26 +1,14 @@
 package com.study.realworld.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.util.Collection;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class UsernameTest {
-
-    private Validator validator;
-
-    @BeforeEach
-    void beforeEach() {
-        validator = Validation.buildDefaultValidatorFactory().getValidator();
-    }
 
     @Test
     void usernameTest() {
@@ -32,48 +20,23 @@ class UsernameTest {
     void usernameNullTest() {
 
         // given
-        Username username = new Username(null);
+        String input = null;
 
-        // when
-        Collection<ConstraintViolation<Username>> constraintViolations
-            = validator.validate(username);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("username must be provided.",
-            constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Username(input))
+            .withMessageMatching("username must be provided.");
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "    "})
     @DisplayName("유저 네임은 빈칸이 들어오면 invalid되어야 한다.")
-    void usernameNothingTest() {
+    void usernameNothingTest(String input) {
 
-        // given
-        Username username = new Username("");
-
-        // when
-        Collection<ConstraintViolation<Username>> constraintViolations
-            = validator.validate(username);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("username must be provided.",
-            constraintViolations.iterator().next().getMessage());
-    }
-
-    @Test
-    @DisplayName("유저 네임은 공백이 들어오면 invalid되어야 한다.")
-    void usernameBlankTest() {
-
-        // given
-        Username username = new Username(" ");
-
-        // when
-        Collection<ConstraintViolation<Username>> constraintViolations
-            = validator.validate(username);
-
-        // then
-        assertEquals(2, constraintViolations.size());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Username(input))
+            .withMessageMatching("username must be provided.");
     }
 
     @Test
@@ -81,16 +44,12 @@ class UsernameTest {
     void usernameMaxSizeTest() {
 
         // given
-        Username username = new Username("123456789012345678901");
+        String input = "123456789012345678901";
 
-        // when
-        Collection<ConstraintViolation<Username>> constraintViolations
-            = validator.validate(username);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("username length must be less than 20 characters.",
-            constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Username(input))
+            .withMessageMatching("username length must be less then 20 characters.");
     }
 
     @Test
@@ -98,14 +57,13 @@ class UsernameTest {
     void usernameValidTest() {
 
         // given
-        Username username = new Username("123가믜힣abcABC");
+        String input = "123가믜힣abcABC";
 
         // when
-        Collection<ConstraintViolation<Username>> constraintViolations
-            = validator.validate(username);
+        Username username = new Username(input);
 
         // then
-        assertEquals(0, constraintViolations.size());
+        assertThat(username.toString()).isEqualTo(input);
     }
 
     @ParameterizedTest
@@ -113,16 +71,10 @@ class UsernameTest {
     @DisplayName("유저네임에 한글, 숫자, 영어 말고 다른 값이 들어오면 invalid되어야한다.")
     void usernameInvalidTest(String input) {
 
-        // given
-        Username username = new Username(input);
-
-        // when
-        Collection<ConstraintViolation<Username>> constraintViolations
-            = validator.validate(username);
-
-        // then
-        assertEquals(1, constraintViolations.size());
-        assertEquals("Invalid username name", constraintViolations.iterator().next().getMessage());
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new Username(input))
+            .withMessageMatching("usernmae must be provided by limited pattern.");
     }
 
     @Test
@@ -130,8 +82,8 @@ class UsernameTest {
     void usernameEqualsHashCodeTest() {
 
         // given
-        Username username = new Username("test@test.com");
-        Username copyUsername = new Username("test@test.com");
+        Username username = new Username("username");
+        Username copyUsername = new Username("username");
 
         // when & then
         assertThat(username)

--- a/src/test/java/com/study/realworld/user/service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/service/UserServiceTest.java
@@ -402,10 +402,8 @@ class UserServiceTest {
                 Password password = new Password("passwordChange");
                 UserUpdateModel userUpdateModel = new UserUpdateModel(null, null,
                     password, null, null);
-                when(passwordEncoder.matches("passwordChange", "encoded_password"))
-                    .thenReturn(false);
-                when(passwordEncoder.encode("passwordChange"))
-                    .thenReturn("encoded_passwordChange");
+                when(passwordEncoder.matches("passwordChange", "encoded_password")).thenReturn(false);
+                when(passwordEncoder.encode("passwordChange")).thenReturn("encoded_Change");
 
                 // when
                 User result = userService.update(userUpdateModel, userId);
@@ -415,7 +413,7 @@ class UserServiceTest {
                 assertThat(result.getEmail()).isEqualTo(originUser.getEmail());
 
                 assertThat(result.getPassword().getPassword())
-                    .isEqualTo("encoded_passwordChange");
+                    .isEqualTo("encoded_Change");
                 assertThat(result.getPassword().getPassword())
                     .isNotEqualTo(originUser.getPassword().getPassword());
 

--- a/src/test/java/com/study/realworld/user/service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/service/UserServiceTest.java
@@ -376,22 +376,20 @@ class UserServiceTest {
         class PasswordTest {
 
             @Test
-            @DisplayName("현재 user와 동일한 password가 들이어오면 변경되지 않아야 한다.")
+            @DisplayName("현재 user와 동일한 password가 들어오면 변경되지 않아야 한다.")
             void updateFailByEqualWithNowPasswordTest() {
 
                 // setup & given
                 Password password = new Password("password");
                 UserUpdateModel userUpdateModel = new UserUpdateModel(null, null,
                     password, null, null);
-                when(passwordEncoder.matches("password", "encoded_password"))
-                    .thenReturn(true);
+                when(passwordEncoder.encode("password")).thenReturn("encoded_password");
 
                 // when
                 User result = userService.update(userUpdateModel, userId);
 
                 // then
-                assertThat(result.getPassword().getPassword())
-                    .isEqualTo(originUser.getPassword().getPassword());
+                assertThat(result.getPassword().getPassword()).isEqualTo(originUser.getPassword().getPassword());
             }
 
             @Test
@@ -402,7 +400,6 @@ class UserServiceTest {
                 Password password = new Password("passwordChange");
                 UserUpdateModel userUpdateModel = new UserUpdateModel(null, null,
                     password, null, null);
-                when(passwordEncoder.matches("passwordChange", "encoded_password")).thenReturn(false);
                 when(passwordEncoder.encode("passwordChange")).thenReturn("encoded_Change");
 
                 // when

--- a/src/test/java/com/study/realworld/user/service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/service/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.study.realworld.user.service;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,7 +53,7 @@ class UserServiceTest {
 
         // setup & given
         User user = User.Builder().build();
-        when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
+        when(userRepository.findByUsername(any())).thenReturn(empty());
         when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
 
         // when & then
@@ -64,8 +66,8 @@ class UserServiceTest {
     void successJoinTest() {
 
         // setup & given
-        when(userRepository.findByUsername(any())).thenReturn(Optional.empty());
-        when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+        when(userRepository.findByUsername(any())).thenReturn(empty());
+        when(userRepository.findByEmail(any())).thenReturn(empty());
         Password password = new Password("password");
         when(passwordEncoder.encode(password.getPassword())).thenReturn("encoded_password");
         User input = User.Builder()
@@ -106,7 +108,7 @@ class UserServiceTest {
         // setup & given
         Email email = new Email("test@test.com");
         Password password = new Password("password");
-        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(email)).thenReturn(empty());
 
         // when && then
         assertThatExceptionOfType(Exception.class)
@@ -121,7 +123,7 @@ class UserServiceTest {
         Email email = new Email("test@test.com");
         Password password = new Password("password");
         User user = User.Builder().password(new Password("encoded_password")).build();
-        when(userRepository.findByEmail(email)).thenReturn(Optional.ofNullable(user));
+        when(userRepository.findByEmail(email)).thenReturn(ofNullable(user));
         when(passwordEncoder.matches("password", "encoded_password")).thenReturn(false);
 
         // when & then
@@ -137,7 +139,7 @@ class UserServiceTest {
         Email email = new Email("test@test.com");
         Password password = new Password("password");
         User input = User.Builder().email(email).password(new Password("encoded_password")).build();
-        when(userRepository.findByEmail(email)).thenReturn(Optional.ofNullable(input));
+        when(userRepository.findByEmail(email)).thenReturn(ofNullable(input));
         when(passwordEncoder.matches("password", "encoded_password")).thenReturn(true);
 
         // when
@@ -147,6 +149,51 @@ class UserServiceTest {
         assertThat(user).isNotNull();
         assertThat(user.getEmail().toString()).isEqualTo("test@test.com");
         assertThat(user.getPassword().getPassword()).isEqualTo("encoded_password");
+    }
+
+    @Test
+    @DisplayName("id를 가지고 유저를 조회할 때 해당 유저가 존재하면 해당 유저를 반환한다.")
+    void findByIdSuccessTest() {
+
+        // setup & given
+        User user = User.Builder().email(new Email("test@test.com")).build();
+        Long userId = 2L;
+        when(userRepository.findById(userId)).thenReturn(ofNullable(user));
+
+        // when
+        Optional<User> result = userService.findById(userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.get().getEmail()).isEqualTo(user.getEmail());
+    }
+
+    @Test
+    @DisplayName("null인 id를 가지고 유저를 조회할 때  IllegalArgumentException이 발생되어야 한다.")
+    void findByNullIdFailTest() {
+
+        // setup & given
+        Long userId = null;
+        when(userRepository.findById(userId)).thenThrow(IllegalArgumentException.class);
+
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> userService.findById(userId));
+    }
+
+    @Test
+    @DisplayName("없는 유저의 id를 가지고 유저를 조회할 때 Optional.empty()가 반환되어야 한다.")
+    void findByNoUserIdFailTest() {
+
+        // setup & given
+        Long userId = 2L;
+        when(userRepository.findById(userId)).thenReturn(empty());
+
+        // when
+        Optional<User> result = userService.findById(userId);
+
+        // then
+        assertThat(result).isEqualTo(empty());
     }
 
 }

--- a/src/test/java/com/study/realworld/user/service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/service/UserServiceTest.java
@@ -75,7 +75,7 @@ class UserServiceTest {
         when(passwordEncoder.encode(password.getPassword())).thenReturn("encoded_password");
         User input = User.Builder()
             .username(new Username("username"))
-            .email(new Email("email"))
+            .email(new Email("test@test.com"))
             .password(password)
             .bio("bio")
             .image("image")
@@ -97,7 +97,7 @@ class UserServiceTest {
         // then
         assertThat(user.getId()).isEqualTo(1L);
         assertThat(user.getUsername()).isEqualTo(new Username("username"));
-        assertThat(user.getEmail()).isEqualTo(new Email("email"));
+        assertThat(user.getEmail()).isEqualTo(new Email("test@test.com"));
         assertThat(user.getPassword().getPassword())
             .isEqualTo("encoded_password");
         assertThat(user.getBio()).isEqualTo("bio");
@@ -207,7 +207,7 @@ class UserServiceTest {
         Long userId = 2L;
         UserUpdateModel userUpdateModel = new UserUpdateModel(
             new Username("username"),
-            new Email("email"),
+            new Email("test@test.com"),
             new Password("password"),
             "bio",
             "image"


### PR DESCRIPTION
## Issue: #16

## 작업 내용
- `GET /api/user`
- `PUT /api/user`

## 생성/변경 로직
- 업데이트 요청 값이 `null`한 값이 들어올 수 있어 `null`에 대한 핸들링이 필요하여 service에 update용 model추가
- 업데이트 불가한 상황들에 대해서 exception 혹은 업데이트 금지 로직 구현
- user entity내 필드 변경 메소드(change...()) 추가
- token 값 가져오는 부분이 공통되어 해당 메소드 분리(`UserController.class`)

## 개인 코멘트
- 두 가지가 제일 어려웠던 것 같아요. `@AuthenticationPrincipal`에 대한 mocking, Validation에 대한 처리
- `@AuthenticationPrincipal`의 경우 현재 단위테스트만 하고 있는 구조상 내부 spring security filter에 대한 더 자세한 모킹이 필요했으나 진행을하다보니 굳이 이걸 하는데 공수가 들어야하나?라는 생각을 했고 단순히 테스팅하였습니다.
- Spring Validation의 가장 큰 단점을 느꼈던 issue였던것 같아요. 파라메터에서만 받을 수 있는 validation의 특성상 update를 구현하는데 있어서 파일을 다 validate하면서 가져오자니 null한값이 들어올 수도 있는 아이러니한 상황이었기 때문이에요. 어쩔 수 없이 valid메소드를 분리하였는데 조금 이상해서 거슬리긴하네요 ... ㅎㅎ
