### PR TITLE
[jwt-example] jwt 가이드라인 코드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,16 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    compile group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtime group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtime group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 apply from: 'test.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    annotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     compile group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtime group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/src/lombok.config
+++ b/src/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
@@ -1,0 +1,48 @@
+package com.study.realworld.global.config;
+
+import com.study.realworld.security.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public WebSecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .csrf()
+            .disable();
+        http
+            .headers()
+            .disable();
+        http
+            .exceptionHandling()
+            .and()
+
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+
+            .authorizeRequests()
+            .anyRequest().authenticated()
+            .and()
+
+            .formLogin()
+            .disable();
+        http
+            .addFilterBefore(jwtAuthenticationFilter,
+                UsernamePasswordAuthenticationFilter.class);
+    }
+
+}

--- a/src/main/java/com/study/realworld/security/JwtAuthentication.java
+++ b/src/main/java/com/study/realworld/security/JwtAuthentication.java
@@ -2,6 +2,11 @@ package com.study.realworld.security;
 
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 
+/**
+ * Security에서 사용하는 인증 객체
+ * Authentication을 그대로 사용하게 된다면 커스텀하게 내가 원하는 값을 ContextHolder에 저장할 수 없음.
+ * 따라서 차후에 principal에 대해 커스텀한 값들을 넣어서 ContextHolder에 원하는 값을 사용할 수 있도록 구현
+ */
 public class JwtAuthentication extends AbstractAuthenticationToken {
 
     private final Object principal;

--- a/src/main/java/com/study/realworld/security/JwtAuthentication.java
+++ b/src/main/java/com/study/realworld/security/JwtAuthentication.java
@@ -1,0 +1,29 @@
+package com.study.realworld.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JwtAuthentication extends AbstractAuthenticationToken {
+
+    private final Object principal;
+
+    private final String credentials;
+
+    public JwtAuthentication(Object principal, String credentials) {
+        super(null);
+        super.setAuthenticated(true);
+
+        this.principal = principal;
+        this.credentials = credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return credentials;
+    }
+
+}

--- a/src/main/java/com/study/realworld/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/study/realworld/security/JwtAuthenticationFilter.java
@@ -11,6 +11,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+/**
+ * filter는 스프링에 들어오기 전 request를 받아서 가장 먼저 처리하는 순서를 가진다. Security에서는 인증을 위해서
+ * UsernamePasswordAuthenticationFilter라는 Filter를 가지는데 이는 default한 filter이다.
+ * 즉, login 당시에는 security없이 아이디, 비밀번호를 통해 로그인하고 이후에는 항상 header에서 jwt를 받기 때문에
+ * filter에 들어올 때 jwt를 받아서 안에 있는 식별자 값을 꺼내오는 filter를 여기서 구현한 것이다.
+ * "Token 토큰내용"의 형태가 기본 스팩이기 때문에 header를 받아 이를 처리하고, JwtProvider에서 jwt를 복호화하여 내부에 들어있는 식별자 정보를 찾는다.
+ * 그 후 controller단에서 인증된 정보를 사용하기 편하게 하기 위해서 SecurityContextHolder내에 식별자와 토큰을 저장해둔다.
+ */
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/study/realworld/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/study/realworld/security/JwtAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package com.study.realworld.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        String[] headers = header.split(" ");
+        if (headers.length == 2 && headers[0].equals("Token") && StringUtils.hasText(headers[1])) {
+            String accessToken = headers[1];
+            Long userId = jwtProvider.getUserId(accessToken);
+            JwtAuthentication authentication = new JwtAuthentication(userId, accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/study/realworld/security/JwtProvider.java
+++ b/src/main/java/com/study/realworld/security/JwtProvider.java
@@ -1,0 +1,48 @@
+package com.study.realworld.security;
+
+import com.study.realworld.user.domain.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+    private final Key key;
+
+    private final long accessTime = 1800000;    // 30분
+
+    public JwtProvider(@Value("${jwt.token") String secret) {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(User user) {
+        long nowTime = (new Date()).getTime();
+        return Jwts.builder()
+            .signWith(key, SignatureAlgorithm.HS512)
+            .setSubject(user.getId().toString())
+            .setExpiration(new Date(nowTime + accessTime))
+            .compact();
+    }
+
+    public Long getUserId(String accessToken) throws Exception {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody();
+            return Long.parseLong(claims.getSubject());
+        } catch (Exception e) {
+            throw new Exception();
+        }
+    }
+
+}

--- a/src/main/java/com/study/realworld/security/JwtProvider.java
+++ b/src/main/java/com/study/realworld/security/JwtProvider.java
@@ -10,15 +10,16 @@ import java.security.Key;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 public class JwtProvider {
 
     private final Key key;
 
     private final long accessTime = 1800000;    // 30분
 
-    public JwtProvider(@Value("${jwt.token") String secret) {
+    public JwtProvider(@Value("${jwt.token}") String secret) {
         byte[] keyBytes = Decoders.BASE64.decode(secret);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
@@ -32,7 +33,7 @@ public class JwtProvider {
             .compact();
     }
 
-    public Long getUserId(String accessToken) throws Exception {
+    public Long getUserId(String accessToken) {
         try {
             Claims claims = Jwts.parserBuilder()
                 .setSigningKey(key)
@@ -41,7 +42,7 @@ public class JwtProvider {
                 .getBody();
             return Long.parseLong(claims.getSubject());
         } catch (Exception e) {
-            throw new Exception();
+            throw new RuntimeException();
         }
     }
 

--- a/src/main/java/com/study/realworld/security/JwtProvider.java
+++ b/src/main/java/com/study/realworld/security/JwtProvider.java
@@ -10,9 +10,13 @@ import java.security.Key;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 
-@Service
+/**
+ * jwt를 생성하거나 jwt를 복호화하는 provider이다.
+ * User를 받아 user내부에 있는 식별자 값을 subject에 저장하여 jwt를 생성한다.
+ * accessToken을 받아 accessToken내부에 이미 저장한 subject를 가져와서 이를 반환한다.
+ */
+@Component
 public class JwtProvider {
 
     private final Key key;

--- a/src/main/java/com/study/realworld/user/controller/UserController.java
+++ b/src/main/java/com/study/realworld/user/controller/UserController.java
@@ -1,0 +1,46 @@
+package com.study.realworld.user.controller;
+
+import static com.study.realworld.user.controller.response.UserResponse.fromUserAndToken;
+
+import com.study.realworld.security.JwtProvider;
+import com.study.realworld.user.controller.request.UserJoinRequest;
+import com.study.realworld.user.controller.request.UserLoginRequest;
+import com.study.realworld.user.controller.response.UserResponse;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    private final JwtProvider jwtProvider;
+
+    public UserController(UserService userService, JwtProvider jwtProvider) {
+        this.userService = userService;
+        this.jwtProvider = jwtProvider;
+    }
+
+    @PostMapping("/users")
+    public ResponseEntity<UserResponse> join(@RequestBody UserJoinRequest request) {
+        User user = userService.join(request.toEntity());
+        String token = "token";
+        return ResponseEntity.ok()
+            .body(fromUserAndToken(user, token));
+    }
+
+    @PostMapping("/users/login")
+    public ResponseEntity<UserResponse> login(@RequestBody UserLoginRequest request) {
+        User user = userService.login(request.getEmail(), request.getPassword());
+        String token = "token";
+        return ResponseEntity.ok()
+            .body(fromUserAndToken(user, token));
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -1,0 +1,32 @@
+package com.study.realworld.user.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.study.realworld.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonTypeName(value = "user")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+public class UserJoinRequest {
+
+    private String username;
+    private String email;
+    private String password;
+    private String bio;
+    private String image;
+
+    public User toEntity() {
+        return User.builder()
+            .username(this.username)
+            .email(this.email)
+            .password(this.password)
+            .bio(this.bio)
+            .image(this.image)
+            .build();
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserJoinRequest.java
@@ -21,11 +21,11 @@ public class UserJoinRequest {
 
     public User toEntity() {
         return User.builder()
-            .username(this.username)
-            .email(this.email)
-            .password(this.password)
-            .bio(this.bio)
-            .image(this.image)
+            .username(username)
+            .email(email)
+            .password(password)
+            .bio(bio)
+            .image(image)
             .build();
     }
 

--- a/src/main/java/com/study/realworld/user/controller/request/UserLoginRequest.java
+++ b/src/main/java/com/study/realworld/user/controller/request/UserLoginRequest.java
@@ -1,0 +1,18 @@
+package com.study.realworld.user.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonTypeName(value = "user")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+public class UserLoginRequest {
+
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
+++ b/src/main/java/com/study/realworld/user/controller/response/UserResponse.java
@@ -1,0 +1,34 @@
+package com.study.realworld.user.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.study.realworld.user.domain.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonTypeName(value = "user")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+public class UserResponse {
+
+    private String username;
+    private String email;
+    private String bio;
+    private String image;
+    private String token;
+
+    public static UserResponse fromUserAndToken(User user, String accessToken) {
+        return new UserResponse(
+            user.getUsername(),
+            user.getEmail(),
+            user.getBio(),
+            user.getImage(),
+            accessToken
+        );
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -1,0 +1,32 @@
+package com.study.realworld.user.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String email;
+
+    private String password;
+
+    private String bio;
+
+    private String image;
+}

--- a/src/main/java/com/study/realworld/user/domain/User.java
+++ b/src/main/java/com/study/realworld/user/domain/User.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Builder
 public class User {
 

--- a/src/main/java/com/study/realworld/user/domain/UserRepository.java
+++ b/src/main/java/com/study/realworld/user/domain/UserRepository.java
@@ -1,0 +1,10 @@
+package com.study.realworld.user.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+}

--- a/src/main/java/com/study/realworld/user/service/UserService.java
+++ b/src/main/java/com/study/realworld/user/service/UserService.java
@@ -1,0 +1,28 @@
+package com.study.realworld.user.service;
+
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User join(User user) {
+        return userRepository.save(user);
+    }
+
+    public User login(String email, String password) {
+        User user = userRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        if(!user.getPassword().equals(password)) {
+            throw new RuntimeException("password miss match");
+        }
+        return user;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,6 @@ spring:
 server:
   port: 8080
 
+jwt:
+  # $ echo 'jwt-example-tutorials-jwt-example-tutorials-jwt-example-tutorials-example' | base64
+  token: and0LWV4YW1wbGUtdHV0b3JpYWxzLWp3dC1leGFtcGxlLXR1dG9yaWFscy1qd3QtZXhhbXBsZS10dXRvcmlhbHMtZXhhbXBsZQo=

--- a/src/test/java/com/study/realworld/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/study/realworld/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,62 @@
+package com.study.realworld.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.study.realworld.user.domain.User;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void beforeEach() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void successFilterTest() throws ServletException, IOException {
+
+        // sestup & given
+        when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Token token");
+        when(jwtProvider.getUserId("token")).thenReturn(2L);
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // when
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // then
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getPrincipal()).isEqualTo(2L);
+        assertThat(authentication.getCredentials()).isEqualTo("token");
+    }
+
+}

--- a/src/test/java/com/study/realworld/security/JwtProviderTest.java
+++ b/src/test/java/com/study/realworld/security/JwtProviderTest.java
@@ -1,0 +1,77 @@
+package com.study.realworld.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.study.realworld.user.domain.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JwtProviderTest {
+
+    private JwtProvider jwtProvider;
+
+    private String secret = "dGVzdF90ZXN0X3Rlc3RfdGVzdF90ZXN0X3Rlc3RfdGVzdF90ZXN0X3Rlc3RfdGVzdF90ZXN0X3Rlc3RfdGVzdF8K";
+
+    @BeforeEach
+    void beforeEach() {
+        jwtProvider = new JwtProvider(secret);
+    }
+
+    @Test
+    void createTokenTest() {
+
+        // given
+        User user = User.builder().id(1L).build();
+
+        // when
+        String result = jwtProvider.createToken(user);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void getUserIdSucessTest() throws Exception {
+
+        // given
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+        long now = (new Date()).getTime();
+        Long id = 2L;
+        String accessToken = Jwts.builder()
+            .setSubject(id.toString())
+            .setExpiration(new Date(now + 300_000))
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+
+        // when
+        Long result = jwtProvider.getUserId(accessToken);
+
+        // then
+        assertThat(result).isEqualTo(2L);
+    }
+
+    @Test
+    void getUserIdFailTest() {
+
+        // given
+        String accessToken = "failToken";
+
+        // when & then
+        assertThatExceptionOfType(Exception.class)
+            .isThrownBy(() -> jwtProvider.getUserId(accessToken));
+
+    }
+}

--- a/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/UserControllerTest.java
@@ -1,0 +1,123 @@
+package com.study.realworld.user.controller;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.study.realworld.security.JwtProvider;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private UserController userController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void beforeEach() {
+        mockMvc = MockMvcBuilders.standaloneSetup(userController)
+            .alwaysExpect(status().isOk())
+            .build();
+    }
+
+    @Test
+    void joinTest() throws Exception {
+
+        // setup
+        User user = User.builder()
+            .username("username")
+            .email("test@test.com")
+            .password("password")
+            .build();
+
+        when(userService.join(any())).thenReturn(user);
+
+        // given
+        final String URL = "/api/users";
+        final String content = "{\"user\":{\"username\":\"" + "username"
+            + "\",\"email\":\"" + "test@test.com"
+            + "\",\"password\":\"" + "password"
+            + "\"}}";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(URL)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+            .andExpect(jsonPath("$.user.username", is("username")))
+            .andExpect(jsonPath("$.user.email", is("test@test.com")))
+            .andExpect(jsonPath("$.user.bio", is(nullValue())))
+            .andExpect(jsonPath("$.user.image", is(nullValue())))
+            .andExpect(jsonPath("$.user.token", is("token")))
+        ;
+    }
+
+    @Test
+    void loginTest() throws Exception {
+
+        // setup
+        User user = User.builder()
+            .username("username")
+            .email("test@test.com")
+            .password("password")
+            .build();
+
+        when(userService.login(any(), any())).thenReturn(user);
+
+        // given
+        final String URL = "/api/users/login";
+        final String content = "{\"user\":{\"email\":\"" + "test@test.com"
+            + "\",\"password\":\"" + "password"
+            + "\"}}";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(URL)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+            .andExpect(jsonPath("$.user.username", is("username")))
+            .andExpect(jsonPath("$.user.email", is("test@test.com")))
+            .andExpect(jsonPath("$.user.bio", is(nullValue())))
+            .andExpect(jsonPath("$.user.image", is(nullValue())))
+            .andExpect(jsonPath("$.user.token", is("token")))
+        ;
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/service/UserServiceTest.java
@@ -1,0 +1,90 @@
+package com.study.realworld.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void joinSuccessTest() {
+
+        // setup & given
+        User user = User.builder().build();
+        when(userRepository.save(any())).thenReturn(user);
+
+        // when
+        User result = userService.join(user);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(user);
+    }
+
+    @Test
+    void loginSuccessTest() {
+
+        // setup & given
+        User user = User.builder()
+            .email("test@test.com")
+            .password("password")
+            .build();
+        String email = "test@test.com";
+        String password = "password";
+        when(userRepository.findByEmail(any())).thenReturn(Optional.ofNullable(user));
+
+        // when
+        User result = userService.login(email, password);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(user);
+    }
+
+    @Test
+    void loginFailByEmailTest() {
+
+        // setup & given
+        User user = User.builder().build();
+        String email = "test@test.com";
+        String password = "password";
+        when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(() -> userService.login(email, password));
+    }
+
+    @Test
+    void loginFailByPasswordTest() {
+
+        // setup & given
+        User user = User.builder().build();
+        String email = "test@test.com";
+        String password = "password";
+        when(userRepository.findByEmail(any()))
+            .thenReturn(Optional.ofNullable(User.builder().build()));
+
+        // when & then
+        assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(() -> userService.login(email, password));
+    }
+
+}

--- a/src/test/java/com/study/realworld/user/service/UserServiceTest.java
+++ b/src/test/java/com/study/realworld/user/service/UserServiceTest.java
@@ -76,11 +76,11 @@ class UserServiceTest {
     void loginFailByPasswordTest() {
 
         // setup & given
-        User user = User.builder().build();
+        User user = User.builder().email("test@test.com").password("password").build();
         String email = "test@test.com";
-        String password = "password";
-        when(userRepository.findByEmail(any()))
-            .thenReturn(Optional.ofNullable(User.builder().build()));
+        String password = "password1";
+        when(userRepository.findByEmail(email))
+            .thenReturn(Optional.ofNullable(user));
 
         // when & then
         assertThatExceptionOfType(RuntimeException.class)


### PR DESCRIPTION
## Issue: 

## 작업 내용
- jwt 가이드라인 코드 추가

## 생성/변경 로직
- JwtProvider : 토큰 생성 및 토큰 복호화 기능
- JwtAuthenticationiFilter : header에 jwt token이 있을 경우 token 복호화 후 security context holder내에 저장

## 개인 코멘트
- 수정해야할 내용 혹은 궁금한 내용 말씀부탁드립니다.
