### PR TITLE
[jinyoungchoi95-issue63] Article 단일조회 /수정 / 삭제 기능 구현

### DIFF
--- a/src/main/java/com/study/realworld/article/controller/ArticleController.java
+++ b/src/main/java/com/study/realworld/article/controller/ArticleController.java
@@ -8,6 +8,7 @@ import com.study.realworld.article.service.ArticleService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +23,12 @@ public class ArticleController {
 
     public ArticleController(ArticleService articleService) {
         this.articleService = articleService;
+    }
+
+    @GetMapping("/articles/{slug}")
+    public ResponseEntity<ArticleResponse> getArticle(@PathVariable String slug) {
+        Article article = articleService.findBySlug(Slug.of(slug));
+        return ResponseEntity.ok().body(ArticleResponse.fromArticle(article));
     }
 
     @PostMapping("/articles")

--- a/src/main/java/com/study/realworld/article/controller/ArticleController.java
+++ b/src/main/java/com/study/realworld/article/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package com.study.realworld.article.controller;
 
 import com.study.realworld.article.controller.request.ArticleCreateRequest;
+import com.study.realworld.article.controller.request.ArticleUpdateRequest;
 import com.study.realworld.article.controller.response.ArticleResponse;
 import com.study.realworld.article.domain.Article;
 import com.study.realworld.article.domain.Slug;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,6 +37,13 @@ public class ArticleController {
     public ResponseEntity<ArticleResponse> createArticle(@RequestBody ArticleCreateRequest request,
         @AuthenticationPrincipal Long loginId) {
         Article article = articleService.createArticle(loginId, request.toArticleContent());
+        return ResponseEntity.ok().body(ArticleResponse.fromArticle(article));
+    }
+
+    @PutMapping("/articles/{slug}")
+    public ResponseEntity<ArticleResponse> updateArticle(@PathVariable String slug,
+        @RequestBody ArticleUpdateRequest request, @AuthenticationPrincipal Long loginId) {
+        Article article = articleService.updateArticle(loginId, Slug.of(slug), request.toArticleUpdateModel());
         return ResponseEntity.ok().body(ArticleResponse.fromArticle(article));
     }
 

--- a/src/main/java/com/study/realworld/article/controller/ArticleController.java
+++ b/src/main/java/com/study/realworld/article/controller/ArticleController.java
@@ -42,7 +42,8 @@ public class ArticleController {
 
     @PutMapping("/articles/{slug}")
     public ResponseEntity<ArticleResponse> updateArticle(@PathVariable String slug,
-        @RequestBody ArticleUpdateRequest request, @AuthenticationPrincipal Long loginId) {
+        @RequestBody ArticleUpdateRequest request,
+        @AuthenticationPrincipal Long loginId) {
         Article article = articleService.updateArticle(loginId, Slug.of(slug), request.toArticleUpdateModel());
         return ResponseEntity.ok().body(ArticleResponse.fromArticle(article));
     }

--- a/src/main/java/com/study/realworld/article/controller/ArticleController.java
+++ b/src/main/java/com/study/realworld/article/controller/ArticleController.java
@@ -3,9 +3,12 @@ package com.study.realworld.article.controller;
 import com.study.realworld.article.controller.request.ArticleCreateRequest;
 import com.study.realworld.article.controller.response.ArticleResponse;
 import com.study.realworld.article.domain.Article;
+import com.study.realworld.article.domain.Slug;
 import com.study.realworld.article.service.ArticleService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +29,11 @@ public class ArticleController {
         @AuthenticationPrincipal Long loginId) {
         Article article = articleService.createArticle(loginId, request.toArticleContent());
         return ResponseEntity.ok().body(ArticleResponse.fromArticle(article));
+    }
+
+    @DeleteMapping("/articles/{slug}")
+    public void deleteArticle(@PathVariable String slug, @AuthenticationPrincipal Long loginId) {
+        articleService.deleteArticleByAuthorAndSlug(loginId, Slug.of(slug));
     }
 
 }

--- a/src/main/java/com/study/realworld/article/controller/request/ArticleUpdateRequest.java
+++ b/src/main/java/com/study/realworld/article/controller/request/ArticleUpdateRequest.java
@@ -1,0 +1,36 @@
+package com.study.realworld.article.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.study.realworld.article.domain.Body;
+import com.study.realworld.article.domain.Description;
+import com.study.realworld.article.domain.Title;
+import com.study.realworld.article.service.model.ArticleUpdateModel;
+import java.util.Optional;
+
+@JsonTypeName(value = "article")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+public class ArticleUpdateRequest {
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("body")
+    private String body;
+
+    ArticleUpdateRequest() {
+    }
+
+    public ArticleUpdateModel toArticleUpdateModel() {
+        return new ArticleUpdateModel(
+            Optional.ofNullable(title).map(Title::of).orElse(null),
+            Optional.ofNullable(description).map(Description::of).orElse(null),
+            Optional.ofNullable(body).map(Body::of).orElse(null)
+        );
+    }
+
+}

--- a/src/main/java/com/study/realworld/article/domain/Article.java
+++ b/src/main/java/com/study/realworld/article/domain/Article.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -30,7 +31,7 @@ public class Article extends BaseTimeEntity {
     private ArticleContent articleContent;
 
     @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_article_to_user_id"))
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private User author;
 
     protected Article() {

--- a/src/main/java/com/study/realworld/article/domain/Article.java
+++ b/src/main/java/com/study/realworld/article/domain/Article.java
@@ -3,6 +3,7 @@ package com.study.realworld.article.domain;
 import com.study.realworld.global.domain.BaseTimeEntity;
 import com.study.realworld.tag.domain.Tag;
 import com.study.realworld.user.domain.User;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import javax.persistence.Embedded;
@@ -66,6 +67,10 @@ public class Article extends BaseTimeEntity {
 
     public User author() {
         return author;
+    }
+
+    public void deleteArticle() {
+        saveDeletedTime(OffsetDateTime.now());
     }
 
     @Override

--- a/src/main/java/com/study/realworld/article/domain/Article.java
+++ b/src/main/java/com/study/realworld/article/domain/Article.java
@@ -70,6 +70,18 @@ public class Article extends BaseTimeEntity {
         return author;
     }
 
+    public void changeTitle(Title title) {
+        articleContent.changeTitle(title);
+    }
+
+    public void changeDescription(Description description) {
+        articleContent.changeDescription(description);
+    }
+
+    public void changeBody(Body body) {
+        articleContent.changeBody(body);
+    }
+
     public void deleteArticle() {
         saveDeletedTime(OffsetDateTime.now());
     }

--- a/src/main/java/com/study/realworld/article/domain/ArticleContent.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleContent.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -25,7 +26,7 @@ public class ArticleContent {
     @JoinTable(name = "article_tag",
         joinColumns = @JoinColumn(name = "article_id"),
         inverseJoinColumns = @JoinColumn(name = "tag_id"))
-    @ManyToMany(cascade = CascadeType.PERSIST)
+    @ManyToMany(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
     private List<Tag> tags;
 
     public ArticleContent() {

--- a/src/main/java/com/study/realworld/article/domain/ArticleContent.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleContent.java
@@ -26,7 +26,7 @@ public class ArticleContent {
     @JoinTable(name = "article_tag",
         joinColumns = @JoinColumn(name = "article_id"),
         inverseJoinColumns = @JoinColumn(name = "tag_id"))
-    @ManyToMany(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<Tag> tags;
 
     public ArticleContent() {

--- a/src/main/java/com/study/realworld/article/domain/ArticleContent.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleContent.java
@@ -59,6 +59,18 @@ public class ArticleContent {
         return tags;
     }
 
+    public void changeTitle(Title title) {
+        slugTitle.changeTitle(title);
+    }
+
+    public void changeDescription(Description description) {
+        this.description = description;
+    }
+
+    public void changeBody(Body body) {
+        this.body = body;
+    }
+
     public ArticleContent refreshTags(List<Tag> tags) {
         this.tags = tags;
         return this;

--- a/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
@@ -1,6 +1,11 @@
 package com.study.realworld.article.domain;
 
+import com.study.realworld.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    Optional<Article> findByAuthorAndArticleContentSlugTitleSlug(User author, Slug slug);
+
 }

--- a/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
+    Optional<Article> findByArticleContentSlugTitleSlug(Slug slug);
+
     Optional<Article> findByAuthorAndArticleContentSlugTitleSlug(User author, Slug slug);
 
 }

--- a/src/main/java/com/study/realworld/article/domain/Slug.java
+++ b/src/main/java/com/study/realworld/article/domain/Slug.java
@@ -22,7 +22,7 @@ public class Slug {
         this.slug = slug;
     }
 
-    static Slug of(String slug) {
+    public static Slug of(String slug) {
         checkSlug(slug);
 
         return new Slug(slug);

--- a/src/main/java/com/study/realworld/article/domain/SlugTitle.java
+++ b/src/main/java/com/study/realworld/article/domain/SlugTitle.java
@@ -33,6 +33,12 @@ public class SlugTitle {
         return title;
     }
 
+    public void changeTitle(Title title) {
+        SlugTitle changeSlugTitle = SlugTitle.of(title);
+        this.title = changeSlugTitle.title;
+        this.slug = changeSlugTitle.slug;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/study/realworld/article/service/ArticleService.java
+++ b/src/main/java/com/study/realworld/article/service/ArticleService.java
@@ -35,7 +35,7 @@ public class ArticleService {
     }
 
     @Transactional
-    public void deleteArticleBySlug(Long userId, Slug slug) {
+    public void deleteArticleByAuthorAndSlug(Long userId, Slug slug) {
         User author = userService.findById(userId);
         Article article = findByAuthorAndSlug(author, slug);
 

--- a/src/main/java/com/study/realworld/article/service/ArticleService.java
+++ b/src/main/java/com/study/realworld/article/service/ArticleService.java
@@ -3,6 +3,9 @@ package com.study.realworld.article.service;
 import com.study.realworld.article.domain.Article;
 import com.study.realworld.article.domain.ArticleContent;
 import com.study.realworld.article.domain.ArticleRepository;
+import com.study.realworld.article.domain.Slug;
+import com.study.realworld.global.exception.BusinessException;
+import com.study.realworld.global.exception.ErrorCode;
 import com.study.realworld.tag.service.TagService;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.service.UserService;
@@ -29,6 +32,19 @@ public class ArticleService {
         articleContent.refreshTags(tagService.refreshTagByExistedTag(articleContent.tags()));
         Article article = Article.from(articleContent, author);
         return articleRepository.save(article);
+    }
+
+    @Transactional
+    public void deleteArticleBySlug(Long userId, Slug slug) {
+        User author = userService.findById(userId);
+        Article article = findByAuthorAndSlug(author, slug);
+
+        article.deleteArticle();
+    }
+
+    private Article findByAuthorAndSlug(User author, Slug slug) {
+        return articleRepository.findByAuthorAndArticleContentSlugTitleSlug(author, slug)
+            .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG));
     }
 
 }

--- a/src/main/java/com/study/realworld/article/service/ArticleService.java
+++ b/src/main/java/com/study/realworld/article/service/ArticleService.java
@@ -25,6 +25,12 @@ public class ArticleService {
         this.tagService = tagService;
     }
 
+    @Transactional(readOnly = true)
+    public Article findBySlug(Slug slug) {
+        return articleRepository.findByArticleContentSlugTitleSlug(slug)
+            .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG));
+    }
+
     @Transactional
     public Article createArticle(Long userId, ArticleContent articleContent) {
         User author = userService.findById(userId);
@@ -44,7 +50,7 @@ public class ArticleService {
 
     private Article findByAuthorAndSlug(User author, Slug slug) {
         return articleRepository.findByAuthorAndArticleContentSlugTitleSlug(author, slug)
-            .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG));
+            .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND_BY_AUTHOR_AND_SLUG));
     }
 
 }

--- a/src/main/java/com/study/realworld/article/service/ArticleService.java
+++ b/src/main/java/com/study/realworld/article/service/ArticleService.java
@@ -4,6 +4,7 @@ import com.study.realworld.article.domain.Article;
 import com.study.realworld.article.domain.ArticleContent;
 import com.study.realworld.article.domain.ArticleRepository;
 import com.study.realworld.article.domain.Slug;
+import com.study.realworld.article.service.model.ArticleUpdateModel;
 import com.study.realworld.global.exception.BusinessException;
 import com.study.realworld.global.exception.ErrorCode;
 import com.study.realworld.tag.service.TagService;
@@ -38,6 +39,18 @@ public class ArticleService {
         articleContent.refreshTags(tagService.refreshTagByExistedTag(articleContent.tags()));
         Article article = Article.from(articleContent, author);
         return articleRepository.save(article);
+    }
+
+    @Transactional
+    public Article updateArticle(Long userId, Slug slug, ArticleUpdateModel updateArticle) {
+        User author = userService.findById(userId);
+        Article article = findByAuthorAndSlug(author, slug);
+
+        updateArticle.getTitle().ifPresent(article::changeTitle);
+        updateArticle.getDescription().ifPresent(article::changeDescription);
+        updateArticle.getBody().ifPresent(article::changeBody);
+
+        return article;
     }
 
     @Transactional

--- a/src/main/java/com/study/realworld/article/service/model/ArticleUpdateModel.java
+++ b/src/main/java/com/study/realworld/article/service/model/ArticleUpdateModel.java
@@ -1,0 +1,32 @@
+package com.study.realworld.article.service.model;
+
+import com.study.realworld.article.domain.Body;
+import com.study.realworld.article.domain.Description;
+import com.study.realworld.article.domain.Title;
+import java.util.Optional;
+
+public class ArticleUpdateModel {
+
+    private final Title title;
+    private final Description description;
+    private final Body body;
+
+    public ArticleUpdateModel(Title title, Description description, Body body) {
+        this.title = title;
+        this.description = description;
+        this.body = body;
+    }
+
+    public Optional<Title> getTitle() {
+        return Optional.ofNullable(title);
+    }
+
+    public Optional<Description> getDescription() {
+        return Optional.ofNullable(description);
+    }
+
+    public Optional<Body> getBody() {
+        return Optional.ofNullable(body);
+    }
+
+}

--- a/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/study/realworld/global/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.study.realworld.global.config;
 
+import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 
 import com.study.realworld.security.JwtAuthenticationEntryPoint;
@@ -61,6 +62,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
             .authorizeRequests()
             .antMatchers(POST, "/api/users", "/api/users/login").permitAll()
+            .antMatchers(GET, "/api/articles/{slug}").permitAll()
             .anyRequest().authenticated()
             .and()
 

--- a/src/main/java/com/study/realworld/global/exception/ErrorCode.java
+++ b/src/main/java/com/study/realworld/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     INVALID_DESCRIPTION_LENGTH(HttpStatus.BAD_REQUEST, "description length must by less than 255 characters."),
     INVALID_BODY_NULL(HttpStatus.BAD_REQUEST, "body must be provided"),
 
+    ARTICLE_NOT_FOUND_BY_AUTHOR_AND_SLUG(HttpStatus.BAD_REQUEST, "article is not found by author and slug"),
     ARTICLE_NOT_FOUND_BY_SLUG(HttpStatus.BAD_REQUEST, "article is not found by slug"),
     ;
 

--- a/src/main/java/com/study/realworld/global/exception/ErrorCode.java
+++ b/src/main/java/com/study/realworld/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     INVALID_DESCRIPTION_LENGTH(HttpStatus.BAD_REQUEST, "description length must by less than 255 characters."),
     INVALID_BODY_NULL(HttpStatus.BAD_REQUEST, "body must be provided"),
 
+    ARTICLE_NOT_FOUND_BY_SLUG(HttpStatus.BAD_REQUEST, "article is not found by slug"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/study/realworld/user/domain/FollowingUsers.java
+++ b/src/main/java/com/study/realworld/user/domain/FollowingUsers.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -17,7 +18,7 @@ public class FollowingUsers {
     @JoinTable(name = "follow",
         joinColumns = @JoinColumn(name = "user_id"),
         inverseJoinColumns = @JoinColumn(name = "follower_id"))
-    @ManyToMany(cascade = CascadeType.ALL)
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<User> followingUsers = new HashSet<>();
 
     protected FollowingUsers() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
         use_sql_comments: true
     hibernate:
       ddl-auto: create
-    open-in-view: false
+    open-in-view: true
   datasource:
     platform: h2
     driver-class-name: org.h2.Driver

--- a/src/test/java/com/study/realworld/article/controller/ArticleControllerTest.java
+++ b/src/test/java/com/study/realworld/article/controller/ArticleControllerTest.java
@@ -7,12 +7,14 @@ import static java.time.format.DateTimeFormatter.ofPattern;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -128,17 +130,13 @@ class ArticleControllerTest {
                 getDocumentRequest(),
                 getDocumentResponse(),
                 responseFields(
-                    fieldWithPath("article.slug").type(JsonFieldType.STRING).description("created article's slug"),
-                    fieldWithPath("article.title").type(JsonFieldType.STRING).description("created article's title"),
-                    fieldWithPath("article.description").type(JsonFieldType.STRING)
-                        .description("created article's description"),
-                    fieldWithPath("article.body").type(JsonFieldType.STRING).description("created article's body"),
-                    fieldWithPath("article.tagList").type(JsonFieldType.ARRAY)
-                        .description("created article's tag's list"),
-                    fieldWithPath("article.createdAt").type(JsonFieldType.STRING)
-                        .description("created article's create time"),
-                    fieldWithPath("article.updatedAt").type(JsonFieldType.STRING)
-                        .description("created article's update time"),
+                    fieldWithPath("article.slug").type(JsonFieldType.STRING).description("article's slug"),
+                    fieldWithPath("article.title").type(JsonFieldType.STRING).description("article's title"),
+                    fieldWithPath("article.description").type(JsonFieldType.STRING).description("article's description"),
+                    fieldWithPath("article.body").type(JsonFieldType.STRING).description("article's body"),
+                    fieldWithPath("article.tagList").type(JsonFieldType.ARRAY).description("article's tag's list"),
+                    fieldWithPath("article.createdAt").type(JsonFieldType.STRING).description("article's create time"),
+                    fieldWithPath("article.updatedAt").type(JsonFieldType.STRING).description("article's update time"),
 
                     fieldWithPath("article.author.username").type(JsonFieldType.STRING)
                         .description("author's username"),
@@ -235,6 +233,104 @@ class ArticleControllerTest {
                         .description("created article's create time"),
                     fieldWithPath("article.updatedAt").type(JsonFieldType.STRING)
                         .description("created article's update time"),
+
+                    fieldWithPath("article.author.username").type(JsonFieldType.STRING)
+                        .description("author's username"),
+                    fieldWithPath("article.author.bio").type(JsonFieldType.STRING).description("author's bio")
+                        .optional(),
+                    fieldWithPath("article.author.image").type(JsonFieldType.STRING).description("author's image")
+                        .optional(),
+                    fieldWithPath("article.author.following").type(JsonFieldType.BOOLEAN)
+                        .description("author's following")
+                )
+            ))
+        ;
+    }
+
+    @Test
+    void updateArticleTest() throws Exception {
+
+        // setup
+        User author = User.Builder()
+            .profile(Username.of("username"), null, null)
+            .email(Email.of("email@email.com"))
+            .password(Password.of("password"))
+            .build();
+        ArticleContent articleContent = ArticleContent.builder()
+            .slugTitle(SlugTitle.of(Title.of("title title")))
+            .description(Description.of("change test article description"))
+            .body(Body.of("change test article body"))
+            .tags(Arrays.asList(Tag.of("tag1"), Tag.of("tag2")))
+            .build();
+        Article article = Article.from(articleContent, author);
+
+        OffsetDateTime now = OffsetDateTime.now();
+        ReflectionTestUtils.setField(article, "createdAt", now);
+        ReflectionTestUtils.setField(article, "updatedAt", now);
+
+        when(articleService.updateArticle(any(), eq(Slug.of("title-title-title")), any())).thenReturn(article);
+
+        // given
+        final String slug = "title-title-title";
+        final String URL = "/api/articles/{slug}";
+        final String content = "{\n"
+            + "  \"article\": {\n"
+            + "    \"title\": \"title title\",\n"
+            + "    \"description\": \"change test article description\",\n"
+            + "    \"body\": \"change test article body\"\n"
+            + "  }\n"
+            + "}";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(put(URL, slug)
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+            .andExpect(jsonPath("$.article.slug", is(article.slug().slug())))
+            .andExpect(jsonPath("$.article.title", is(article.title().title())))
+            .andExpect(jsonPath("$.article.description", is(article.description().description())))
+            .andExpect(jsonPath("$.article.body", is(article.body().body())))
+            .andExpect(jsonPath("$.article.tagList[0]", is(article.tags().get(0).name())))
+            .andExpect(jsonPath("$.article.tagList[1]", is(article.tags().get(1).name())))
+            .andExpect(jsonPath("$.article.createdAt",
+                is(article.updatedAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
+            .andExpect(jsonPath("$.article.updatedAt",
+                is(article.updatedAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
+            .andExpect(jsonPath("$.article.author.username", is(article.author().username().value())))
+            .andExpect(jsonPath("$.article.author.bio", is(nullValue())))
+            .andExpect(jsonPath("$.article.author.image", is(nullValue())))
+            .andExpect(jsonPath("$.article.author.following", is(false)))
+
+            .andDo(document("article-create",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestFields(
+                    fieldWithPath("article.title").type(JsonFieldType.STRING).description("article title").optional(),
+                    fieldWithPath("article.description").type(JsonFieldType.STRING).description("article description")
+                        .optional(),
+                    fieldWithPath("article.body").type(JsonFieldType.STRING).description("article body")
+                        .optional(),
+                    fieldWithPath("article.tagList").type(JsonFieldType.ARRAY).description("article tag's list")
+                        .optional()
+                ),
+                responseFields(
+                    fieldWithPath("article.slug").type(JsonFieldType.STRING).description("changed article's slug"),
+                    fieldWithPath("article.title").type(JsonFieldType.STRING).description("changed article's title"),
+                    fieldWithPath("article.description").type(JsonFieldType.STRING)
+                        .description("created article's description"),
+                    fieldWithPath("article.body").type(JsonFieldType.STRING).description("changed article's body"),
+                    fieldWithPath("article.tagList").type(JsonFieldType.ARRAY)
+                        .description("article's tag's list"),
+                    fieldWithPath("article.createdAt").type(JsonFieldType.STRING)
+                        .description("article's create time"),
+                    fieldWithPath("article.updatedAt").type(JsonFieldType.STRING)
+                        .description("article's update time"),
 
                     fieldWithPath("article.author.username").type(JsonFieldType.STRING)
                         .description("author's username"),

--- a/src/test/java/com/study/realworld/article/controller/ArticleControllerTest.java
+++ b/src/test/java/com/study/realworld/article/controller/ArticleControllerTest.java
@@ -11,10 +11,11 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -24,6 +25,7 @@ import com.study.realworld.article.domain.Article;
 import com.study.realworld.article.domain.ArticleContent;
 import com.study.realworld.article.domain.Body;
 import com.study.realworld.article.domain.Description;
+import com.study.realworld.article.domain.Slug;
 import com.study.realworld.article.domain.SlugTitle;
 import com.study.realworld.article.domain.Title;
 import com.study.realworld.article.service.ArticleService;
@@ -68,6 +70,87 @@ class ArticleControllerTest {
             .apply(documentationConfiguration(restDocumentationContextProvider))
             .alwaysExpect(status().isOk())
             .build();
+    }
+
+    @Test
+    void getArticleTest() throws Exception {
+
+        // setup
+        User author = User.Builder()
+            .profile(Username.of("username"), null, null)
+            .email(Email.of("email@email.com"))
+            .password(Password.of("password"))
+            .build();
+        ArticleContent articleContent = ArticleContent.builder()
+            .slugTitle(SlugTitle.of(Title.of("title title title")))
+            .description(Description.of("test article description"))
+            .body(Body.of("test article body"))
+            .tags(Arrays.asList(Tag.of("tag1"), Tag.of("tag2")))
+            .build();
+        Article article = Article.from(articleContent, author);
+
+        OffsetDateTime now = OffsetDateTime.now();
+        ReflectionTestUtils.setField(article, "createdAt", now);
+        ReflectionTestUtils.setField(article, "updatedAt", now);
+
+        when(articleService.findBySlug(Slug.of("title-title-title"))).thenReturn(article);
+
+        // given
+        final String slug = "title-title-title";
+        final String URL = "/api/articles/{slug}";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get(URL, slug)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+            .andExpect(jsonPath("$.article.slug", is(article.slug().slug())))
+            .andExpect(jsonPath("$.article.title", is(article.title().title())))
+            .andExpect(jsonPath("$.article.description", is(article.description().description())))
+            .andExpect(jsonPath("$.article.body", is(article.body().body())))
+            .andExpect(jsonPath("$.article.tagList[0]", is(article.tags().get(0).name())))
+            .andExpect(jsonPath("$.article.tagList[1]", is(article.tags().get(1).name())))
+            .andExpect(jsonPath("$.article.createdAt",
+                is(article.updatedAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
+            .andExpect(jsonPath("$.article.updatedAt",
+                is(article.updatedAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
+            .andExpect(jsonPath("$.article.author.username", is(article.author().username().value())))
+            .andExpect(jsonPath("$.article.author.bio", is(nullValue())))
+            .andExpect(jsonPath("$.article.author.image", is(nullValue())))
+            .andExpect(jsonPath("$.article.author.following", is(false)))
+
+            .andDo(document("article-find",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                responseFields(
+                    fieldWithPath("article.slug").type(JsonFieldType.STRING).description("created article's slug"),
+                    fieldWithPath("article.title").type(JsonFieldType.STRING).description("created article's title"),
+                    fieldWithPath("article.description").type(JsonFieldType.STRING)
+                        .description("created article's description"),
+                    fieldWithPath("article.body").type(JsonFieldType.STRING).description("created article's body"),
+                    fieldWithPath("article.tagList").type(JsonFieldType.ARRAY)
+                        .description("created article's tag's list"),
+                    fieldWithPath("article.createdAt").type(JsonFieldType.STRING)
+                        .description("created article's create time"),
+                    fieldWithPath("article.updatedAt").type(JsonFieldType.STRING)
+                        .description("created article's update time"),
+
+                    fieldWithPath("article.author.username").type(JsonFieldType.STRING)
+                        .description("author's username"),
+                    fieldWithPath("article.author.bio").type(JsonFieldType.STRING).description("author's bio")
+                        .optional(),
+                    fieldWithPath("article.author.image").type(JsonFieldType.STRING).description("author's image")
+                        .optional(),
+                    fieldWithPath("article.author.following").type(JsonFieldType.BOOLEAN)
+                        .description("author's following")
+                )
+            ))
+        ;
     }
 
     @Test

--- a/src/test/java/com/study/realworld/article/controller/ArticleControllerTest.java
+++ b/src/test/java/com/study/realworld/article/controller/ArticleControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -161,6 +162,29 @@ class ArticleControllerTest {
                     fieldWithPath("article.author.following").type(JsonFieldType.BOOLEAN)
                         .description("author's following")
                 )
+            ))
+        ;
+    }
+
+    @Test
+    void deleteArticleTest() throws Exception {
+
+        // given
+        String slug = "title-title-title";
+        final String URL = "/api/articles/{slug}";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(delete(URL, slug)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+
+            .andDo(document("article-delete",
+                getDocumentRequest(),
+                getDocumentResponse()
             ))
         ;
     }

--- a/src/test/java/com/study/realworld/article/domain/ArticleContentTest.java
+++ b/src/test/java/com/study/realworld/article/domain/ArticleContentTest.java
@@ -6,10 +6,26 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.study.realworld.tag.domain.Tag;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ArticleContentTest {
+
+    private Title title;
+    private SlugTitle slugTitle;
+    private Description description;
+    private Body body;
+    private List<Tag> tags;
+
+    @BeforeEach
+    void beforeEach() {
+        title = Title.of("title");
+        slugTitle = SlugTitle.of(title);
+        description = Description.of("description");
+        body = Body.of("body");
+        tags = Arrays.asList(Tag.of("tag1"), Tag.of("tag2"));
+    }
 
     @Test
     void articleContentTest() {
@@ -17,15 +33,59 @@ class ArticleContentTest {
     }
 
     @Test
-    @DisplayName("builder test")
-    void articleContentBuilderTest() {
+    @DisplayName("title을 변경할 수 있다.")
+    void changeTitleTest() {
 
         // given
-        Title title = Title.of("title");
-        SlugTitle slugTitle = SlugTitle.of(title);
-        Description description = Description.of("description");
-        Body body = Body.of("body");
-        List<Tag> tags = Arrays.asList(Tag.of("tag1"), Tag.of("tag2"));
+        Title changeTitle = Title.of("title title");
+        ArticleContent articleContent = ArticleContent.builder()
+            .slugTitle(SlugTitle.of(title)).build();
+
+        // when
+        articleContent.changeTitle(changeTitle);
+
+        // then
+        assertAll(
+            () -> assertThat(articleContent.title()).isEqualTo(changeTitle),
+            () -> assertThat(articleContent.slug()).isEqualTo(Slug.of(changeTitle.titleToSlug()))
+        );
+    }
+
+    @Test
+    @DisplayName("description을 변경할 수 있다.")
+    void changeDescriptionTest() {
+
+        // given
+        Description changeDescription = Description.of("new description");
+        ArticleContent articleContent = ArticleContent.builder()
+            .description(description).build();
+
+        // when
+        articleContent.changeDescription(changeDescription);
+
+        // then
+        assertThat(articleContent.description()).isEqualTo(changeDescription);
+    }
+
+    @Test
+    @DisplayName("body를 변경할 수 있다.")
+    void changeBodyTest() {
+
+        // given
+        Body changeBody = Body.of("new body");
+        ArticleContent articleContent = ArticleContent.builder()
+            .body(body).build();
+
+        // when
+        articleContent.changeBody(changeBody);
+
+        // then
+        assertThat(articleContent.body()).isEqualTo(changeBody);
+    }
+
+    @Test
+    @DisplayName("builder test")
+    void articleContentBuilderTest() {
 
         // when
         ArticleContent result = ArticleContent.builder()
@@ -48,13 +108,6 @@ class ArticleContentTest {
     @Test
     @DisplayName("equals hashCode 테스트")
     void articleContentEqualsHashCodeTest() {
-
-        // given
-        Title title = Title.of("title");
-        SlugTitle slugTitle = SlugTitle.of(title);
-        Description description = Description.of("description");
-        Body body = Body.of("body");
-        List<Tag> tags = Arrays.asList(Tag.of("tag1"), Tag.of("tag2"));
 
         // when
         ArticleContent result = ArticleContent.builder()

--- a/src/test/java/com/study/realworld/article/domain/ArticleTest.java
+++ b/src/test/java/com/study/realworld/article/domain/ArticleTest.java
@@ -1,6 +1,7 @@
 package com.study.realworld.article.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.study.realworld.tag.domain.Tag;
 import com.study.realworld.user.domain.Bio;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 class ArticleTest {
 
     private User author;
+    private ArticleContent articleContent;
 
     @BeforeEach
     void beforeEach() {
@@ -25,6 +27,12 @@ class ArticleTest {
             .email(Email.of("email@email.com"))
             .password(Password.of("password"))
             .profile(Username.of("username"), Bio.of("bio"), Image.of("image"))
+            .build();
+        articleContent = ArticleContent.builder()
+            .slugTitle(SlugTitle.of(Title.of("title")))
+            .description(Description.of("description"))
+            .body(Body.of("body"))
+            .tags(Arrays.asList(Tag.of("tag1"), Tag.of("tag2")))
             .build();
     }
 
@@ -34,15 +42,58 @@ class ArticleTest {
     }
 
     @Test
+    @DisplayName("title을 변경할 수 있다.")
+    void changeTitleTest() {
+
+        // given
+        Title changeTitle = Title.of("title title");
+        Article article = Article.from(articleContent, author);
+
+        // when
+        article.changeTitle(changeTitle);
+
+        // then
+        assertAll(
+            () -> assertThat(article.title()).isEqualTo(changeTitle),
+            () -> assertThat(article.slug()).isEqualTo(Slug.of(changeTitle.titleToSlug()))
+        );
+    }
+
+    @Test
+    @DisplayName("description을 변경할 수 있다.")
+    void changeDescriptionTest() {
+
+        // given
+        Description changeDescription = Description.of("new description");
+        Article article = Article.from(articleContent, author);
+
+        // when
+        article.changeDescription(changeDescription);
+
+        // then
+        assertThat(article.description()).isEqualTo(changeDescription);
+    }
+
+    @Test
+    @DisplayName("body를 변경할 수 있다.")
+    void changeBodyTest() {
+
+        // given
+        Body changeBody = Body.of("new body");
+        Article article = Article.from(articleContent, author);
+
+        // when
+        article.changeBody(changeBody);
+
+        // then
+        assertThat(article.body()).isEqualTo(changeBody);
+    }
+
+    @Test
     @DisplayName("Article을 삭제할 때 삭제 시간을 저장할 수 있다.")
     void deleteArticleTest() {
 
         // given
-        ArticleContent articleContent = ArticleContent.builder()
-            .slugTitle(SlugTitle.of(Title.of("title")))
-            .description(Description.of("description"))
-            .body(Body.of("body"))
-            .build();
         Article article = Article.from(articleContent, author);
         OffsetDateTime startTime = OffsetDateTime.now();
         article.deleteArticle();
@@ -58,14 +109,6 @@ class ArticleTest {
     @Test
     @DisplayName("equals hashCode 테스트")
     void articleEqualsHashCodeTest() {
-
-        // given
-        ArticleContent articleContent = ArticleContent.builder()
-            .slugTitle(SlugTitle.of(Title.of("title")))
-            .description(Description.of("description"))
-            .body(Body.of("body"))
-            .tags(Arrays.asList(Tag.of("tag")))
-            .build();
 
         // when
         Article result = Article.from(articleContent, author);

--- a/src/test/java/com/study/realworld/article/domain/ArticleTest.java
+++ b/src/test/java/com/study/realworld/article/domain/ArticleTest.java
@@ -9,6 +9,7 @@ import com.study.realworld.user.domain.Image;
 import com.study.realworld.user.domain.Password;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.Username;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +31,28 @@ class ArticleTest {
     @Test
     void articleTest() {
         Article article = new Article();
+    }
+
+    @Test
+    @DisplayName("Article을 삭제할 때 삭제 시간을 저장할 수 있다.")
+    void deleteArticleTest() {
+
+        // given
+        ArticleContent articleContent = ArticleContent.builder()
+            .slugTitle(SlugTitle.of(Title.of("title")))
+            .description(Description.of("description"))
+            .body(Body.of("body"))
+            .build();
+        Article article = Article.from(articleContent, author);
+        OffsetDateTime startTime = OffsetDateTime.now();
+        article.deleteArticle();
+        OffsetDateTime endTime = OffsetDateTime.now();
+
+        // when
+        OffsetDateTime result = article.deletedAt();
+
+        // then
+        assertThat(result).isAfter(startTime).isBefore(endTime);
     }
 
     @Test

--- a/src/test/java/com/study/realworld/article/domain/SlugTitleTest.java
+++ b/src/test/java/com/study/realworld/article/domain/SlugTitleTest.java
@@ -13,6 +13,23 @@ class SlugTitleTest {
     }
 
     @Test
+    @DisplayName("SlugTitle을 받아 변경할 수 있다.")
+    void changeTitleTest() {
+
+        // given
+        SlugTitle slugTitle = SlugTitle.of(Title.of("title title title"));
+        Title title = Title.of("title title");
+
+        SlugTitle expected = SlugTitle.of(title);
+
+        // when
+        slugTitle.changeTitle(title);
+
+        // then
+        assertThat(slugTitle).isEqualTo(expected);
+    }
+
+    @Test
     @DisplayName("equals hashCode 테스트")
     void slugTitleEqualsHashCodeTest() {
 

--- a/src/test/java/com/study/realworld/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/study/realworld/article/service/ArticleServiceTest.java
@@ -68,6 +68,43 @@ class ArticleServiceTest {
             .build();
     }
 
+    @Nested
+    @DisplayName("findBySlug Article 단일 조회 테스트")
+    class findBySlugTest {
+
+        @Test
+        @DisplayName("slug를 가지고 article을 조회할 수 있다.")
+        void findBySlugSuccessTest() {
+
+            // given
+            Article expected = Article.from(articleContent, user);
+            when(articleRepository.findByArticleContentSlugTitleSlug(expected.slug()))
+                .thenReturn(Optional.of(expected));
+
+            // when
+            Article result = articleService.findBySlug(expected.slug());
+
+            // then
+            assertThat(result).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("없는 article을 조회하려고할 때 exception이 발생해야 한다.")
+        void findBySlugExceptionTest() {
+
+            // given
+            Article article = Article.from(articleContent, user);
+            when(articleRepository.findByArticleContentSlugTitleSlug(article.slug()))
+                .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> articleService.findBySlug(article.slug()))
+                .withMessageMatching(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG.getMessage());
+        }
+
+    }
+
     @Test
     @DisplayName("user id를 가지고 article을 생성할 수 있다.")
     void createArticleTest() {
@@ -88,7 +125,7 @@ class ArticleServiceTest {
     }
 
     @Nested
-    @DisplayName("deleteARticleBySlug Article 삭제 테스트")
+    @DisplayName("deleteArticleBySlug Article 삭제 테스트")
     class deleteArticleBySlug {
 
         @Test
@@ -121,7 +158,7 @@ class ArticleServiceTest {
             // when & then
             assertThatExceptionOfType(BusinessException.class)
                 .isThrownBy(() -> articleService.deleteArticleByAuthorAndSlug(userId, slug))
-                .withMessageMatching(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG.getMessage());
+                .withMessageMatching(ErrorCode.ARTICLE_NOT_FOUND_BY_AUTHOR_AND_SLUG.getMessage());
         }
 
         @Test

--- a/src/test/java/com/study/realworld/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/study/realworld/article/service/ArticleServiceTest.java
@@ -103,7 +103,7 @@ class ArticleServiceTest {
 
             // when & then
             assertThatExceptionOfType(BusinessException.class)
-                .isThrownBy(() -> articleService.deleteArticleBySlug(userId, slug))
+                .isThrownBy(() -> articleService.deleteArticleByAuthorAndSlug(userId, slug))
                 .withMessageMatching(ErrorCode.USER_NOT_FOUND.getMessage());
         }
 
@@ -120,7 +120,7 @@ class ArticleServiceTest {
 
             // when & then
             assertThatExceptionOfType(BusinessException.class)
-                .isThrownBy(() -> articleService.deleteArticleBySlug(userId, slug))
+                .isThrownBy(() -> articleService.deleteArticleByAuthorAndSlug(userId, slug))
                 .withMessageMatching(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG.getMessage());
         }
 
@@ -136,7 +136,7 @@ class ArticleServiceTest {
             when(articleRepository.findByAuthorAndArticleContentSlugTitleSlug(user, slug))
                 .thenReturn(Optional.of(article));
             OffsetDateTime start = OffsetDateTime.now();
-            articleService.deleteArticleBySlug(userId, slug);
+            articleService.deleteArticleByAuthorAndSlug(userId, slug);
             OffsetDateTime end = OffsetDateTime.now();
 
             // when

--- a/src/test/java/com/study/realworld/user/controller/ProfileControllerTest.java
+++ b/src/test/java/com/study/realworld/user/controller/ProfileControllerTest.java
@@ -134,7 +134,7 @@ class ProfileControllerTest {
             .andExpect(jsonPath("$.profile.bio", is("bio")))
             .andExpect(jsonPath("$.profile.image", is("image")))
             .andExpect(jsonPath("$.profile.following", is(true)))
-            .andDo(document("get-profile",
+            .andDo(document("follow-profile",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 pathParameters(
@@ -179,7 +179,7 @@ class ProfileControllerTest {
             .andExpect(jsonPath("$.profile.bio", is("bio")))
             .andExpect(jsonPath("$.profile.image", is("image")))
             .andExpect(jsonPath("$.profile.following", is(false)))
-            .andDo(document("get-profile",
+            .andDo(document("unfollow-profile",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 pathParameters(


### PR DESCRIPTION
## Issue: #63 

## 작업 내용
- 게시글 단일 조회 기능 구현
- 게시글 업데이트 기능 구현
- 게시글 삭제 기능 구현

## 생성/변경 로직
- Article내에 delete_at 추가기능 구현 (soft delete)
- Article field update 메소드 구현

## 개인 코멘트
- 로직짜는거 자체는 이전 user 도메인과 똑같아서 크게 어려운점 없이 기능 추가한 것 같네요.
- 다만 authentication을 optional 하게 주는 api들이 몇가지 있을 것 같은데 차후에 정리해서 적용해야할 것 같아요 :)
