### PR TITLE
[jinyoungchoi95-issue65] Article 전체 조회 기능

### DIFF
--- a/src/docs/https/article/article.http
+++ b/src/docs/https/article/article.http
@@ -1,0 +1,8 @@
+### find article
+GET localhost:8080/api/articles/{{slug}}
+Content-Type: application/json
+
+### get articles
+GET localhost:8080/api/articles?offset=0&limit=4&tag=reactjs&author=Jacob
+Content-Type: application/json; charset=utf-8
+Authorization: Token {{Authorization}}

--- a/src/docs/https/article/article_create.http
+++ b/src/docs/https/article/article_create.http
@@ -1,0 +1,158 @@
+### create article
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon1",
+    "description": "Ever wonder how?1",
+    "body": "You have to believe1",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+> {%
+ client.global.set("slug", response.body.article.slug);
+ client.log("created Authorization : " + client.global.get("Authorization"));
+%}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon2",
+    "description": "Ever wonder how?2",
+    "body": "You have to believe2",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon3",
+    "description": "Ever wonder how?3",
+    "body": "You have to believe3",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon4",
+    "description": "Ever wonder how?4",
+    "body": "You have to believe4",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon5",
+    "description": "Ever wonder how?5",
+    "body": "You have to believe5",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon6",
+    "description": "Ever wonder how?6",
+    "body": "You have to believe6",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon7",
+    "description": "Ever wonder how?7",
+    "body": "You have to believe7",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon8",
+    "description": "Ever wonder how?8",
+    "body": "You have to believe8",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon9",
+    "description": "Ever wonder how?9",
+    "body": "You have to believe9",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon10",
+    "description": "Ever wonder how?10",
+    "body": "You have to believe10",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}
+
+### create articles
+POST localhost:8080/api/articles
+Content-Type: application/json
+Authorization: Token {{Authorization}}
+
+{
+  "article": {
+    "title": "How to train your dragon11",
+    "description": "Ever wonder how?11",
+    "body": "You have to believe11",
+    "tagList": ["reactjs", "angularjs", "dragons"]
+  }
+}

--- a/src/docs/https/article/user.http
+++ b/src/docs/https/article/user.http
@@ -1,0 +1,41 @@
+### join
+POST localhost:8080/api/users
+Content-Type: application/json
+
+{
+  "user": {
+    "username": "Jacob",
+    "email": "jake@jake.jake",
+    "password": "jakejake"
+  }
+}
+
+### login
+POST localhost:8080/api/users/login
+Content-Type: application/json
+
+{
+  "user": {
+    "email": "jake@jake.jake",
+    "password": "jakejake"
+  }
+}
+
+> {%
+ client.global.set("Authorization", response.body.user.token);
+ client.log("created Authorization: " + client.global.get("Authorization"));
+%}
+
+### update
+PUT localhost:8080/api/user
+Authorization: Token {{Authorization}}
+Content-Type: application/json
+
+{
+  "user": {
+    "email": "jake@jake2.jake",
+    "bio": "I like to skateboard",
+    "image": "https://i.stack.imgur.com/xHWG8.jpg"
+  }
+}
+

--- a/src/main/java/com/study/realworld/article/controller/ArticleController.java
+++ b/src/main/java/com/study/realworld/article/controller/ArticleController.java
@@ -3,9 +3,13 @@ package com.study.realworld.article.controller;
 import com.study.realworld.article.controller.request.ArticleCreateRequest;
 import com.study.realworld.article.controller.request.ArticleUpdateRequest;
 import com.study.realworld.article.controller.response.ArticleResponse;
+import com.study.realworld.article.controller.response.ArticlesResponse;
 import com.study.realworld.article.domain.Article;
 import com.study.realworld.article.domain.Slug;
 import com.study.realworld.article.service.ArticleService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api")
@@ -31,6 +36,14 @@ public class ArticleController {
     public ResponseEntity<ArticleResponse> getArticle(@PathVariable String slug) {
         Article article = articleService.findBySlug(Slug.of(slug));
         return ResponseEntity.ok().body(ArticleResponse.fromArticle(article));
+    }
+
+    @GetMapping("/articles")
+    public ResponseEntity<ArticlesResponse> getArticles(@PageableDefault(page = 0, size = 20) Pageable pageable,
+        @RequestParam(required = false) String tag, @RequestParam(required = false) String author,
+        @RequestParam(required = false) String favorited) {
+        Page<Article> articles = articleService.findAllArticles(pageable, tag, author);
+        return ResponseEntity.ok().body(ArticlesResponse.fromPageArticles(articles));
     }
 
     @PostMapping("/articles")

--- a/src/main/java/com/study/realworld/article/controller/response/ArticleResponse.java
+++ b/src/main/java/com/study/realworld/article/controller/response/ArticleResponse.java
@@ -2,108 +2,88 @@ package com.study.realworld.article.controller.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.study.realworld.article.domain.Article;
 import com.study.realworld.article.domain.Body;
 import com.study.realworld.article.domain.Description;
 import com.study.realworld.article.domain.Slug;
 import com.study.realworld.article.domain.Title;
 import com.study.realworld.tag.domain.Tag;
-import com.study.realworld.user.domain.Bio;
-import com.study.realworld.user.domain.Image;
-import com.study.realworld.user.domain.Profile;
-import com.study.realworld.user.domain.Username;
+import com.study.realworld.user.controller.response.ProfileResponse.ProfileResponseNested;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-@JsonTypeName(value = "article")
-@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 public class ArticleResponse {
 
-    @JsonProperty("slug")
-    private Slug slug;
-
-    @JsonProperty("title")
-    private Title title;
-
-    @JsonProperty("description")
-    private Description description;
-
-    @JsonProperty("body")
-    private Body body;
-
-    @JsonProperty("tagList")
-    private List<Tag> tags;
-
-    @JsonProperty("createdAt")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
-    private OffsetDateTime createdAt;
-
-    @JsonProperty("updatedAt")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
-    private OffsetDateTime updatedAt;
-
-    @JsonProperty("author")
-    private AuthorProfile authorProfile;
+    @JsonProperty("article")
+    private ArticleResponseNested articleResponseNested;
 
     ArticleResponse() {
     }
 
-    private ArticleResponse(Slug slug, Title title, Description description, Body body,
-        List<Tag> tags, OffsetDateTime createdAt, OffsetDateTime updatedAt,
-        AuthorProfile authorProfile) {
-        this.slug = slug;
-        this.title = title;
-        this.description = description;
-        this.body = body;
-        this.tags = tags;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.authorProfile = authorProfile;
+    private ArticleResponse(ArticleResponseNested articleResponseNested) {
+        this.articleResponseNested = articleResponseNested;
     }
 
     public static ArticleResponse fromArticle(Article article) {
-        return new ArticleResponse(
-            article.slug(),
-            article.title(),
-            article.description(),
-            article.body(),
-            article.tags(),
-            article.createdAt(),
-            article.updatedAt(),
-            new AuthorProfile(article.author().profile())
-        );
+        return new ArticleResponse(ArticleResponseNested.fromArticle(article));
     }
 
-    public static class AuthorProfile {
+    public static class ArticleResponseNested {
 
-        @JsonProperty("username")
-        private Username username;
+        @JsonProperty("slug")
+        private Slug slug;
 
-        @JsonProperty("bio")
-        private Bio bio;
+        @JsonProperty("title")
+        private Title title;
 
-        @JsonProperty("image")
-        private Image image;
+        @JsonProperty("description")
+        private Description description;
 
-        @JsonProperty("following")
-        private boolean following;
+        @JsonProperty("body")
+        private Body body;
 
-        AuthorProfile() {
+        @JsonProperty("tagList")
+        private List<Tag> tags;
+
+        @JsonProperty("createdAt")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+        private OffsetDateTime createdAt;
+
+        @JsonProperty("updatedAt")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+        private OffsetDateTime updatedAt;
+
+        @JsonProperty("author")
+        private ProfileResponseNested profileResponseNested;
+
+        ArticleResponseNested() {
         }
 
-        public AuthorProfile(Username username, Bio bio, Image image, boolean following) {
-            this.username = username;
-            this.bio = bio;
-            this.image = image;
-            this.following = following;
+        private ArticleResponseNested(Slug slug, Title title, Description description, Body body, List<Tag> tags,
+            OffsetDateTime createdAt, OffsetDateTime updatedAt, ProfileResponseNested profileResponseNested) {
+            this.slug = slug;
+            this.title = title;
+            this.description = description;
+            this.body = body;
+            this.tags = tags;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+            this.profileResponseNested = profileResponseNested;
         }
 
-        public AuthorProfile(Profile profile) {
-            this(profile.username(), profile.bio(), profile.image(), profile.isFollow());
+        public static ArticleResponseNested fromArticle(Article article) {
+            return new ArticleResponseNested(
+                article.slug(),
+                article.title(),
+                article.description(),
+                article.body(),
+                article.tags(),
+                article.createdAt(),
+                article.updatedAt(),
+                ProfileResponseNested.ofProfile(article.author().profile())
+            );
         }
-
     }
+
 
 }

--- a/src/main/java/com/study/realworld/article/controller/response/ArticleResponse.java
+++ b/src/main/java/com/study/realworld/article/controller/response/ArticleResponse.java
@@ -50,7 +50,7 @@ public class ArticleResponse {
     ArticleResponse() {
     }
 
-    public ArticleResponse(Slug slug, Title title, Description description, Body body,
+    private ArticleResponse(Slug slug, Title title, Description description, Body body,
         List<Tag> tags, OffsetDateTime createdAt, OffsetDateTime updatedAt,
         AuthorProfile authorProfile) {
         this.slug = slug;

--- a/src/main/java/com/study/realworld/article/controller/response/ArticlesResponse.java
+++ b/src/main/java/com/study/realworld/article/controller/response/ArticlesResponse.java
@@ -1,0 +1,35 @@
+package com.study.realworld.article.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.study.realworld.article.controller.response.ArticleResponse.ArticleResponseNested;
+import com.study.realworld.article.domain.Article;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+
+public class ArticlesResponse {
+
+    @JsonProperty("articles")
+    private List<ArticleResponseNested> articleResponseNesteds;
+
+    @JsonProperty("articlesCount")
+    private int articlesCount;
+
+    ArticlesResponse() {
+    }
+
+    private ArticlesResponse(List<ArticleResponseNested> articleResponseNesteds, int articlesCount) {
+        this.articleResponseNesteds = articleResponseNesteds;
+        this.articlesCount = articlesCount;
+    }
+
+    public static ArticlesResponse fromPageArticles(Page<Article> articles) {
+        return new ArticlesResponse(
+            articles.getContent().stream()
+                .map(ArticleResponseNested::fromArticle)
+                .collect(Collectors.toList()),
+            articles.getSize()
+        );
+    }
+
+}

--- a/src/main/java/com/study/realworld/article/domain/ArticleContent.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleContent.java
@@ -10,6 +10,7 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import org.hibernate.annotations.BatchSize;
 
 @Embeddable
 public class ArticleContent {
@@ -23,6 +24,7 @@ public class ArticleContent {
     @Embedded
     private Body body;
 
+    @BatchSize(size = 100)
     @JoinTable(name = "article_tag",
         joinColumns = @JoinColumn(name = "article_id"),
         inverseJoinColumns = @JoinColumn(name = "tag_id"))

--- a/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
@@ -2,12 +2,33 @@ package com.study.realworld.article.domain;
 
 import com.study.realworld.user.domain.User;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
+    @EntityGraph(attributePaths = {"author"}, type = EntityGraphType.FETCH)
     Optional<Article> findByArticleContentSlugTitleSlug(Slug slug);
 
+    @EntityGraph(attributePaths = {"author"}, type = EntityGraphType.FETCH)
     Optional<Article> findByAuthorAndArticleContentSlugTitleSlug(User author, Slug slug);
+
+    @EntityGraph(attributePaths = {"author"}, type = EntityGraphType.FETCH)
+    @Query(
+        value = "select distinct a "
+            + "from Article a "
+            + "join a.author u "
+            + "inner join a.articleContent.tags t "
+            + "where "
+            + "(:author is null or :author = u.profile.username.name) "
+            + "and "
+            + "(:tag is null or :tag = t.name) "
+            + "order by a.createdAt"
+    )
+    Page<Article> findPageByAuthorAndTag(Pageable pageable, String author, String tag);
 
 }

--- a/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
@@ -24,11 +24,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             + "join a.author u "
             + "inner join a.articleContent.tags t "
             + "where "
-            + "(:author is null or :author = u.profile.username.name) "
-            + "and "
             + "(:tag is null or :tag = t.name) "
+            + "and "
+            + "(:author is null or :author = u.profile.username.name) "
             + "order by a.createdAt"
     )
-    Page<Article> findPageByAuthorAndTag(Pageable pageable, String author, String tag);
+    Page<Article> findPageByTagAndAuthor(Pageable pageable, String tag, String author);
 
 }

--- a/src/main/java/com/study/realworld/article/service/ArticleService.java
+++ b/src/main/java/com/study/realworld/article/service/ArticleService.java
@@ -35,8 +35,8 @@ public class ArticleService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Article> findAllArticles(Pageable pageable, String author, String tag) {
-        return articleRepository.findPageByAuthorAndTag(pageable, author, tag);
+    public Page<Article> findAllArticles(Pageable pageable, String tag, String author) {
+        return articleRepository.findPageByTagAndAuthor(pageable, tag, author);
     }
 
     @Transactional

--- a/src/main/java/com/study/realworld/article/service/ArticleService.java
+++ b/src/main/java/com/study/realworld/article/service/ArticleService.java
@@ -11,7 +11,7 @@ import com.study.realworld.tag.service.TagService;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.service.UserService;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,8 +35,8 @@ public class ArticleService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Article> findAllArticles(PageRequest pageRequest, String author, String tag) {
-        return articleRepository.findPageByAuthorAndTag(pageRequest, author, tag);
+    public Page<Article> findAllArticles(Pageable pageable, String author, String tag) {
+        return articleRepository.findPageByAuthorAndTag(pageable, author, tag);
     }
 
     @Transactional

--- a/src/main/java/com/study/realworld/article/service/ArticleService.java
+++ b/src/main/java/com/study/realworld/article/service/ArticleService.java
@@ -10,6 +10,8 @@ import com.study.realworld.global.exception.ErrorCode;
 import com.study.realworld.tag.service.TagService;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.service.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,11 @@ public class ArticleService {
     public Article findBySlug(Slug slug) {
         return articleRepository.findByArticleContentSlugTitleSlug(slug)
             .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Article> findAllArticles(PageRequest pageRequest, String author, String tag) {
+        return articleRepository.findPageByAuthorAndTag(pageRequest, author, tag);
     }
 
     @Transactional

--- a/src/main/java/com/study/realworld/global/config/WebConfig.java
+++ b/src/main/java/com/study/realworld/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.study.realworld.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public PageableHandlerMethodArgumentResolverCustomizer customizer() {
+        return pageableResolver -> {
+            pageableResolver.setPageParameterName("offset");
+            pageableResolver.setSizeParameterName("limit");
+        };
+    }
+
+}

--- a/src/main/java/com/study/realworld/user/controller/response/ProfileResponse.java
+++ b/src/main/java/com/study/realworld/user/controller/response/ProfileResponse.java
@@ -1,62 +1,60 @@
 package com.study.realworld.user.controller.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.study.realworld.user.domain.Bio;
 import com.study.realworld.user.domain.Image;
 import com.study.realworld.user.domain.Profile;
 import com.study.realworld.user.domain.Username;
 
-@JsonTypeName("profile")
-@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 public class ProfileResponse {
 
-    @JsonProperty("username")
-    private Username username;
+    @JsonProperty("profile")
+    private ProfileResponseNested profileResponseNested;
 
-    @JsonProperty("bio")
-    private Bio bio;
-
-    @JsonProperty("image")
-    private Image image;
-
-    @JsonProperty("following")
-    private boolean following;
-
-    protected ProfileResponse() {
+    ProfileResponse() {
     }
 
-    private ProfileResponse(Username username, Bio bio, Image image, boolean following) {
-        this.username = username;
-        this.bio = bio;
-        this.image = image;
-        this.following = following;
-    }
-
-    public Username getUsername() {
-        return username;
-    }
-
-    public Bio getBio() {
-        return bio;
-    }
-
-    public Image getImage() {
-        return image;
-    }
-
-    public boolean isFollowing() {
-        return following;
+    private ProfileResponse(ProfileResponseNested profileResponseNested) {
+        this.profileResponseNested = profileResponseNested;
     }
 
     public static ProfileResponse ofProfile(Profile profile) {
-        return new ProfileResponse(
-            profile.username(),
-            profile.bio(),
-            profile.image(),
-            profile.isFollow()
-        );
+        return new ProfileResponse(ProfileResponseNested.ofProfile(profile));
+    }
+
+    public static class ProfileResponseNested {
+
+        @JsonProperty("username")
+        private Username username;
+
+        @JsonProperty("bio")
+        private Bio bio;
+
+        @JsonProperty("image")
+        private Image image;
+
+        @JsonProperty("following")
+        private boolean following;
+
+        ProfileResponseNested() {
+        }
+
+        private ProfileResponseNested(Username username, Bio bio, Image image, boolean following) {
+            this.username = username;
+            this.bio = bio;
+            this.image = image;
+            this.following = following;
+        }
+
+        public static ProfileResponseNested ofProfile(Profile profile) {
+            return new ProfileResponseNested (
+                profile.username(),
+                profile.bio(),
+                profile.image(),
+                profile.isFollow()
+            );
+        }
+
     }
 
 }

--- a/src/test/java/com/study/realworld/article/controller/response/ArticleResponseTest.java
+++ b/src/test/java/com/study/realworld/article/controller/response/ArticleResponseTest.java
@@ -1,6 +1,6 @@
 package com.study.realworld.article.controller.response;
 
-import com.study.realworld.article.controller.response.ArticleResponse.AuthorProfile;
+import com.study.realworld.article.controller.response.ArticleResponse.ArticleResponseNested;
 import org.junit.jupiter.api.Test;
 
 class ArticleResponseTest {
@@ -8,11 +8,7 @@ class ArticleResponseTest {
     @Test
     void articleResponseTest() {
         ArticleResponse articleResponse = new ArticleResponse();
-    }
-
-    @Test
-    void authorProfileTest() {
-        AuthorProfile authorProfile = new AuthorProfile();
+        ArticleResponseNested articleResponseNested = new ArticleResponseNested();
     }
 
 }

--- a/src/test/java/com/study/realworld/article/controller/response/ArticlesResponseTest.java
+++ b/src/test/java/com/study/realworld/article/controller/response/ArticlesResponseTest.java
@@ -1,0 +1,12 @@
+package com.study.realworld.article.controller.response;
+
+import org.junit.jupiter.api.Test;
+
+class ArticlesResponseTest {
+
+    @Test
+    void articlesResponseTest() {
+        ArticlesResponse articlesResponse = new ArticlesResponse();
+    }
+
+}

--- a/src/test/java/com/study/realworld/article/domain/ArticleRepositoryTest.java
+++ b/src/test/java/com/study/realworld/article/domain/ArticleRepositoryTest.java
@@ -90,8 +90,8 @@ class ArticleRepositoryTest {
     }
 
     @Test
-    @DisplayName("findAllTest")
-    void findAllByNameSuccessTest() {
+    @DisplayName("특정 tag와 username을 가진 작성자의 article을 검색할 수 있다.")
+    void findAllByAuthornameTagSuccessTest() {
 
         // given
         int offset = 0;

--- a/src/test/java/com/study/realworld/article/domain/ArticleRepositoryTest.java
+++ b/src/test/java/com/study/realworld/article/domain/ArticleRepositoryTest.java
@@ -1,0 +1,120 @@
+package com.study.realworld.article.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.study.realworld.global.config.JpaConfiguration;
+import com.study.realworld.tag.domain.Tag;
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.Password;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.UserRepository;
+import com.study.realworld.user.domain.Username;
+import java.util.Arrays;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest(includeFilters = @ComponentScan.Filter(
+    type = FilterType.ASSIGNABLE_TYPE,
+    classes = JpaConfiguration.class
+))
+class ArticleRepositoryTest {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void beforeEach() {
+        String username = "user";
+        String email = "@test.com";
+        for (int i = 1; i <= 10; i++) {
+            userRepository.save(User.Builder()
+                .profile(Username.of(username + i), null, null)
+                .email(Email.of(username + i + email))
+                .password(Password.of("password"))
+                .build());
+        }
+
+        String title = "title";
+        String description = "description";
+        String body = "body";
+        User author1 = userRepository.findById(1L).orElse(null);
+        for (int i = 1; i <= 10; i++) {
+            ArticleContent articleContent = ArticleContent.builder()
+                .slugTitle(SlugTitle.of(Title.of(title + i)))
+                .description(Description.of(description + i))
+                .body(Body.of(body + i))
+                .tags(Arrays.asList(Tag.of("tag" + i), Tag.of("tagA")))
+                .build();
+            Article article = articleRepository.save(Article.from(articleContent, author1));
+            System.out.println("input article tag " + i + " : " + article.tags().get(0).name());
+        }
+
+        User author2 = userRepository.findById(2L).orElse(null);
+        for (int i = 11; i <= 20; i++) {
+            ArticleContent articleContent = ArticleContent.builder()
+                .slugTitle(SlugTitle.of(Title.of(title + i)))
+                .description(Description.of(description + i))
+                .body(Body.of(body + i))
+                .tags(Arrays.asList(Tag.of("tag" + i), Tag.of("tagB")))
+                .build();
+            articleRepository.save(Article.from(articleContent, author2));
+        }
+
+        User author3 = userRepository.findById(3L).orElse(null);
+        for (int i = 21; i <= 30; i++) {
+            ArticleContent articleContent = ArticleContent.builder()
+                .slugTitle(SlugTitle.of(Title.of(title + i)))
+                .description(Description.of(description + i))
+                .body(Body.of(body + i))
+                .tags(Arrays.asList(Tag.of("tag" + i), Tag.of("tagC")))
+                .build();
+            articleRepository.save(Article.from(articleContent, author3));
+        }
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("findAllTest")
+    void findAllByNameSuccessTest() {
+
+        // given
+        int offset = 0;
+        int limit = 4;
+        PageRequest pageRequest = PageRequest.of(offset, limit);
+
+        // when
+        Page<Article> result = articleRepository.findPageByAuthorAndTag(pageRequest, "user1", "tagA");
+
+        // then
+        assertAll(
+            () -> assertThat(result.getSize()).isEqualTo(limit),    // now page content's count
+            () -> assertThat(result.getNumber()).isEqualTo(offset),  // now page number
+            () -> assertThat(result.getTotalPages()).isEqualTo(3),  // totla page count
+            () -> {
+                for (Article article : result) {
+                    assertAll(
+                        () -> assertThat(article.author().username()).isEqualTo(Username.of("user1")),
+                        () -> assertThat(article.tags()).contains(Tag.of("tagA"))
+                    );
+                }
+            }
+        );
+    }
+
+}

--- a/src/test/java/com/study/realworld/article/domain/ArticleRepositoryTest.java
+++ b/src/test/java/com/study/realworld/article/domain/ArticleRepositoryTest.java
@@ -99,7 +99,7 @@ class ArticleRepositoryTest {
         PageRequest pageRequest = PageRequest.of(offset, limit);
 
         // when
-        Page<Article> result = articleRepository.findPageByAuthorAndTag(pageRequest, "user1", "tagA");
+        Page<Article> result = articleRepository.findPageByTagAndAuthor(pageRequest, "tagA", "user1");
 
         // then
         assertAll(

--- a/src/test/java/com/study/realworld/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/study/realworld/article/service/ArticleServiceTest.java
@@ -25,6 +25,7 @@ import com.study.realworld.user.domain.Username;
 import com.study.realworld.user.service.UserService;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +35,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class ArticleServiceTest {
@@ -288,5 +292,34 @@ class ArticleServiceTest {
             assertThat(result).isAfter(start).isBefore(end);
         }
     }
+
+    @Test
+    @DisplayName("원하는 offset, limit을 가진 Page 리스트를 반환할 수 있다.")
+    void findAllArticlesByOffsetLimitTest() {
+
+        // setup & given
+        int offset = 0;
+        int limit = 4;
+        List<Article> articles = Arrays.asList(Article.from(articleContent, user),
+            Article.from(articleContent, user),
+            Article.from(articleContent, user),
+            Article.from(articleContent, user),
+            Article.from(articleContent, user)
+        );
+        PageRequest pageRequest = PageRequest.of(offset, limit);
+        when(articleRepository.findPageByAuthorAndTag(pageRequest, null, null))
+            .thenReturn(new PageImpl<>(articles.subList(0, 4), pageRequest, articles.size()));
+
+        // when
+        Page<Article> result = articleService.findAllArticles(pageRequest, null, null);
+
+        // then
+        assertAll(
+            () -> assertThat(result.getSize()).isEqualTo(limit),
+            () -> assertThat(result.getNumber()).isEqualTo(offset),
+            () -> assertThat(result.getTotalPages()).isEqualTo(2)
+        );
+    }
+
 
 }

--- a/src/test/java/com/study/realworld/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/study/realworld/article/service/ArticleServiceTest.java
@@ -307,7 +307,7 @@ class ArticleServiceTest {
             Article.from(articleContent, user)
         );
         PageRequest pageRequest = PageRequest.of(offset, limit);
-        when(articleRepository.findPageByAuthorAndTag(pageRequest, null, null))
+        when(articleRepository.findPageByTagAndAuthor(pageRequest, null, null))
             .thenReturn(new PageImpl<>(articles.subList(0, 4), pageRequest, articles.size()));
 
         // when

--- a/src/test/java/com/study/realworld/user/controller/response/ProfileResponseTest.java
+++ b/src/test/java/com/study/realworld/user/controller/response/ProfileResponseTest.java
@@ -1,5 +1,6 @@
 package com.study.realworld.user.controller.response;
 
+import com.study.realworld.user.controller.response.ProfileResponse.ProfileResponseNested;
 import org.junit.jupiter.api.Test;
 
 class ProfileResponseTest {
@@ -7,6 +8,7 @@ class ProfileResponseTest {
     @Test
     void profileResponseTest() {
         ProfileResponse profileResponse = new ProfileResponse();
+        ProfileResponseNested profileResponseNested = new ProfileResponseNested();
     }
 
 }


### PR DESCRIPTION
## Issue: #65 

## 작업 내용
- 게시글 전체 조회 기능 구현
  - tag param filtering
  - author param filtering
  - limit, offset param filtering

## 생성/변경 로직
- ArticleRepository 내 filtering 쿼리 추가
- Fetch join을 위한 `@EntityGraph` 추가
- Pageable 인터페이스 설정 조절

## 개인 코멘트
- Jpql 쿼리짜는데 잘못 구현한 부분이 많아서 이상하게 엉켰던 구현내용인 것 같네요 :rofl:
- 이번 구현을 진행하면서 Pagenation에서의 n+1문제에 대한 고민을 많이 할 수 있어서 좋았던 것 같아요. 어떤 부분에서 n+1이 발생하는지 찾고 개선해나가는 과정이 있어서 더 이해가 빠를 수 있었던 것 같네요 :)
- favorited 부분은 일단 article favorite 부분을 구현한 후에 구현할 예정입니다 :)