### PR TITLE
[jinyoungchoi95-issue67] Comment 추가/조회/삭제 기능 구현

### DIFF
--- a/src/main/java/com/study/realworld/article/comment/controller/CommentController.java
+++ b/src/main/java/com/study/realworld/article/comment/controller/CommentController.java
@@ -1,0 +1,34 @@
+package com.study.realworld.article.comment.controller;
+
+import com.study.realworld.article.comment.controller.request.CommentCreateRequest;
+import com.study.realworld.article.comment.controller.response.CommentResponse;
+import com.study.realworld.article.comment.domain.Comment;
+import com.study.realworld.article.comment.service.CommentService;
+import com.study.realworld.article.domain.Slug;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api")
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @PostMapping("/articles/{slug}/comments")
+    public ResponseEntity<CommentResponse> createComment(@PathVariable String slug,
+        @RequestBody CommentCreateRequest request,
+        @AuthenticationPrincipal Long loginId) {
+        Comment comment = commentService.createComment(loginId, Slug.of(slug), request.toCommentBody());
+        return ResponseEntity.ok().body(CommentResponse.fromComment(comment));
+    }
+
+}

--- a/src/main/java/com/study/realworld/article/comment/controller/CommentController.java
+++ b/src/main/java/com/study/realworld/article/comment/controller/CommentController.java
@@ -2,11 +2,14 @@ package com.study.realworld.article.comment.controller;
 
 import com.study.realworld.article.comment.controller.request.CommentCreateRequest;
 import com.study.realworld.article.comment.controller.response.CommentResponse;
+import com.study.realworld.article.comment.controller.response.CommentsResponse;
 import com.study.realworld.article.comment.domain.Comment;
 import com.study.realworld.article.comment.service.CommentService;
 import com.study.realworld.article.domain.Slug;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +24,12 @@ public class CommentController {
 
     public CommentController(CommentService commentService) {
         this.commentService = commentService;
+    }
+
+    @GetMapping("/articles/{slug}/comments")
+    public ResponseEntity<CommentsResponse> getCommentByArticleSlug(@PathVariable String slug) {
+        List<Comment> comments = commentService.getCommentsByArticleSlug(Slug.of(slug));
+        return ResponseEntity.ok().body(CommentsResponse.fromComments(comments));
     }
 
     @PostMapping("/articles/{slug}/comments")

--- a/src/main/java/com/study/realworld/article/comment/controller/CommentController.java
+++ b/src/main/java/com/study/realworld/article/comment/controller/CommentController.java
@@ -9,6 +9,7 @@ import com.study.realworld.article.domain.Slug;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,6 +39,12 @@ public class CommentController {
         @AuthenticationPrincipal Long loginId) {
         Comment comment = commentService.createComment(loginId, Slug.of(slug), request.toCommentBody());
         return ResponseEntity.ok().body(CommentResponse.fromComment(comment));
+    }
+
+    @DeleteMapping("/articles/{slug}/comments/{id}")
+    public void deleteComment(@PathVariable String slug, @PathVariable Long id,
+        @AuthenticationPrincipal Long loginId) {
+        commentService.deleteCommentByCommentId(loginId, Slug.of(slug), id);
     }
 
 }

--- a/src/main/java/com/study/realworld/article/comment/controller/request/CommentCreateRequest.java
+++ b/src/main/java/com/study/realworld/article/comment/controller/request/CommentCreateRequest.java
@@ -15,10 +15,6 @@ public class CommentCreateRequest {
     CommentCreateRequest() {
     }
 
-    private CommentCreateRequest(String body) {
-        this.body = body;
-    }
-
     public CommentBody toCommentBody() {
         return CommentBody.of(body);
     }

--- a/src/main/java/com/study/realworld/article/comment/controller/request/CommentCreateRequest.java
+++ b/src/main/java/com/study/realworld/article/comment/controller/request/CommentCreateRequest.java
@@ -1,0 +1,26 @@
+package com.study.realworld.article.comment.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.study.realworld.article.comment.domain.CommentBody;
+
+@JsonTypeName(value = "comment")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+public class CommentCreateRequest {
+
+    @JsonProperty("body")
+    private String body;
+
+    CommentCreateRequest() {
+    }
+
+    private CommentCreateRequest(String body) {
+        this.body = body;
+    }
+
+    public CommentBody toCommentBody() {
+        return CommentBody.of(body);
+    }
+
+}

--- a/src/main/java/com/study/realworld/article/comment/controller/response/CommentResponse.java
+++ b/src/main/java/com/study/realworld/article/comment/controller/response/CommentResponse.java
@@ -1,0 +1,68 @@
+package com.study.realworld.article.comment.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.study.realworld.article.comment.domain.Comment;
+import com.study.realworld.article.comment.domain.CommentBody;
+import com.study.realworld.user.controller.response.ProfileResponse.ProfileResponseNested;
+import java.time.OffsetDateTime;
+
+public class CommentResponse {
+
+    @JsonProperty("comment")
+    private CommentResponseNested commentResponseNested;
+
+    CommentResponse() {
+    }
+
+    private CommentResponse(CommentResponseNested commentResponseNested) {
+        this.commentResponseNested = commentResponseNested;
+    }
+
+    public static CommentResponse fromComment(Comment comment) {
+        return new CommentResponse(CommentResponseNested.fromComment(comment));
+    }
+
+    public static class CommentResponseNested {
+
+        @JsonProperty("id")
+        private Long id;
+
+        @JsonProperty("createdAt")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+        private OffsetDateTime createdAt;
+
+        @JsonProperty("updatedAt")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+        private OffsetDateTime updatedAt;
+
+        @JsonProperty("body")
+        private CommentBody commentBody;
+
+        @JsonProperty("author")
+        private ProfileResponseNested profileResponseNested;
+
+        CommentResponseNested() {
+        }
+
+        public CommentResponseNested(Long id, OffsetDateTime createdAt, OffsetDateTime updatedAt,
+            CommentBody commentBody,
+            ProfileResponseNested profileResponseNested) {
+            this.id = id;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+            this.commentBody = commentBody;
+            this.profileResponseNested = profileResponseNested;
+        }
+
+        public static CommentResponseNested fromComment(Comment comment) {
+            return new CommentResponseNested(
+                comment.id(),
+                comment.createdAt(),
+                comment.updatedAt(),
+                comment.commentBody(),
+                ProfileResponseNested.ofProfile(comment.author().profile())
+            );
+        }
+    }
+}

--- a/src/main/java/com/study/realworld/article/comment/controller/response/CommentsResponse.java
+++ b/src/main/java/com/study/realworld/article/comment/controller/response/CommentsResponse.java
@@ -1,0 +1,29 @@
+package com.study.realworld.article.comment.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.study.realworld.article.comment.controller.response.CommentResponse.CommentResponseNested;
+import com.study.realworld.article.comment.domain.Comment;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CommentsResponse {
+
+    @JsonProperty("comments")
+    private List<CommentResponseNested> commentResponseNesteds;
+
+    CommentsResponse() {
+    }
+
+    private CommentsResponse(List<CommentResponseNested> commentResponseNesteds) {
+        this.commentResponseNesteds = commentResponseNesteds;
+    }
+
+    public static CommentsResponse fromComments(List<Comment> comments) {
+        return new CommentsResponse(
+            comments.stream()
+                .map(CommentResponseNested::fromComment)
+                .collect(Collectors.toList())
+        );
+    }
+
+}

--- a/src/main/java/com/study/realworld/article/comment/domain/Comment.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/Comment.java
@@ -2,6 +2,8 @@ package com.study.realworld.article.comment.domain;
 
 import com.study.realworld.article.domain.Article;
 import com.study.realworld.global.domain.BaseTimeEntity;
+import com.study.realworld.global.exception.BusinessException;
+import com.study.realworld.global.exception.ErrorCode;
 import com.study.realworld.user.domain.User;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -62,8 +64,16 @@ public class Comment extends BaseTimeEntity {
         return article;
     }
 
-    public void deleteComment() {
+    public void deleteCommentByAuthor(User author) {
+        checkCommentAuthor(author);
+
         saveDeletedTime(OffsetDateTime.now());
+    }
+
+    private void checkCommentAuthor(User author) {
+        if (!Objects.equals(this.author, author)) {
+            throw new BusinessException(ErrorCode.INVALID_COMMENT_AUTHOR_DISMATCH);
+        }
     }
 
     @Override

--- a/src/main/java/com/study/realworld/article/comment/domain/Comment.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/Comment.java
@@ -1,0 +1,78 @@
+package com.study.realworld.article.comment.domain;
+
+import com.study.realworld.article.domain.Article;
+import com.study.realworld.global.domain.BaseTimeEntity;
+import com.study.realworld.user.domain.User;
+import java.util.Objects;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private CommentBody commentBody;
+
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_comment_to_user_id"))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User author;
+
+    @JoinColumn(name = "article_id", nullable = false, foreignKey = @ForeignKey(name = "fk_comment_to_article_id"))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Article article;
+
+    protected Comment() {
+    }
+
+    private Comment(CommentBody commentBody, User author, Article article) {
+        this.commentBody = commentBody;
+        this.author = author;
+        this.article = article;
+    }
+
+    public static Comment from(CommentBody commentBody, User author, Article article) {
+        return new Comment(commentBody, author, article);
+    }
+
+    public CommentBody commentBody() {
+        return commentBody;
+    }
+
+    public User author() {
+        return author;
+    }
+
+    public Article article() {
+        return article;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Comment comment = (Comment) o;
+        return Objects.equals(commentBody, comment.commentBody) && Objects
+            .equals(author, comment.author) && Objects.equals(article, comment.article);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(commentBody, author, article);
+    }
+
+}

--- a/src/main/java/com/study/realworld/article/comment/domain/Comment.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/Comment.java
@@ -45,6 +45,10 @@ public class Comment extends BaseTimeEntity {
         return new Comment(commentBody, author, article);
     }
 
+    public Long id() {
+        return id;
+    }
+
     public CommentBody commentBody() {
         return commentBody;
     }

--- a/src/main/java/com/study/realworld/article/comment/domain/Comment.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/Comment.java
@@ -16,8 +16,10 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import org.hibernate.annotations.Where;
 
 @Entity
+@Where(clause = "deleted_at is null")
 public class Comment extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/study/realworld/article/comment/domain/Comment.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/Comment.java
@@ -3,6 +3,7 @@ package com.study.realworld.article.comment.domain;
 import com.study.realworld.article.domain.Article;
 import com.study.realworld.global.domain.BaseTimeEntity;
 import com.study.realworld.user.domain.User;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -59,6 +60,10 @@ public class Comment extends BaseTimeEntity {
 
     public Article article() {
         return article;
+    }
+
+    public void deleteComment() {
+        saveDeletedTime(OffsetDateTime.now());
     }
 
     @Override

--- a/src/main/java/com/study/realworld/article/comment/domain/CommentBody.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/CommentBody.java
@@ -1,0 +1,56 @@
+package com.study.realworld.article.comment.domain;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.study.realworld.global.exception.ErrorCode;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class CommentBody {
+
+    @Column(name = "body", columnDefinition = "text", nullable = false)
+    private String body;
+
+    protected CommentBody() {
+    }
+
+    private CommentBody(String body) {
+        this.body = body;
+    }
+
+    public static CommentBody of(String body) {
+        checkBody(body);
+
+        return new CommentBody(body);
+    }
+
+    public static void checkBody(String body) {
+        checkArgument(Objects.nonNull(body), ErrorCode.INVALID_COMMENT_BODY_NULL);
+    }
+
+    @JsonValue
+    public String body() {
+        return body;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CommentBody body1 = (CommentBody) o;
+        return Objects.equals(body, body1.body);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(body);
+    }
+
+}

--- a/src/main/java/com/study/realworld/article/comment/domain/CommentRepository.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/CommentRepository.java
@@ -2,10 +2,13 @@ package com.study.realworld.article.comment.domain;
 
 import com.study.realworld.article.domain.Article;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByArticle(Article article);
+
+    Optional<Comment> findByIdAndArticle(Long id, Article article);
 
 }

--- a/src/main/java/com/study/realworld/article/comment/domain/CommentRepository.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/CommentRepository.java
@@ -1,6 +1,11 @@
 package com.study.realworld.article.comment.domain;
 
+import com.study.realworld.article.domain.Article;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findAllByArticle(Article article);
+
 }

--- a/src/main/java/com/study/realworld/article/comment/domain/CommentRepository.java
+++ b/src/main/java/com/study/realworld/article/comment/domain/CommentRepository.java
@@ -1,0 +1,6 @@
+package com.study.realworld.article.comment.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/study/realworld/article/comment/service/CommentService.java
+++ b/src/main/java/com/study/realworld/article/comment/service/CommentService.java
@@ -8,6 +8,7 @@ import com.study.realworld.article.domain.Slug;
 import com.study.realworld.article.service.ArticleService;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.service.UserService;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,13 @@ public class CommentService {
         this.commentRepository = commentRepository;
         this.userService = userService;
         this.articleService = articleService;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Comment> getCommentsByArticleSlug(Slug slug) {
+        Article article = articleService.findBySlug(slug);
+
+        return commentRepository.findAllByArticle(article);
     }
 
     @Transactional

--- a/src/main/java/com/study/realworld/article/comment/service/CommentService.java
+++ b/src/main/java/com/study/realworld/article/comment/service/CommentService.java
@@ -6,6 +6,8 @@ import com.study.realworld.article.comment.domain.CommentRepository;
 import com.study.realworld.article.domain.Article;
 import com.study.realworld.article.domain.Slug;
 import com.study.realworld.article.service.ArticleService;
+import com.study.realworld.global.exception.BusinessException;
+import com.study.realworld.global.exception.ErrorCode;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.service.UserService;
 import java.util.List;
@@ -39,6 +41,20 @@ public class CommentService {
 
         Comment comment = Comment.from(commentBody, author, article);
         return commentRepository.save(comment);
+    }
+
+    @Transactional
+    public void deleteCommentByCommentId(Long userId, Slug slug, Long commentId) {
+        User author = userService.findById(userId);
+        Article article = articleService.findBySlug(slug);
+
+        Comment comment = findByIdAndArticle(commentId, article);
+        comment.deleteCommentByAuthor(author);
+    }
+
+    private Comment findByIdAndArticle(Long id, Article article) {
+        return commentRepository.findByIdAndArticle(id, article)
+            .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_COMMENT_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/study/realworld/article/comment/service/CommentService.java
+++ b/src/main/java/com/study/realworld/article/comment/service/CommentService.java
@@ -1,0 +1,36 @@
+package com.study.realworld.article.comment.service;
+
+import com.study.realworld.article.comment.domain.Comment;
+import com.study.realworld.article.comment.domain.CommentBody;
+import com.study.realworld.article.comment.domain.CommentRepository;
+import com.study.realworld.article.domain.Article;
+import com.study.realworld.article.domain.Slug;
+import com.study.realworld.article.service.ArticleService;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.service.UserService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserService userService;
+    private final ArticleService articleService;
+
+    public CommentService(CommentRepository commentRepository, UserService userService, ArticleService articleService) {
+        this.commentRepository = commentRepository;
+        this.userService = userService;
+        this.articleService = articleService;
+    }
+
+    @Transactional
+    public Comment createComment(Long userId, Slug slug, CommentBody commentBody) {
+        User author = userService.findById(userId);
+        Article article = articleService.findBySlug(slug);
+
+        Comment comment = Comment.from(commentBody, author, article);
+        return commentRepository.save(comment);
+    }
+
+}

--- a/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
+++ b/src/main/java/com/study/realworld/article/domain/ArticleRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
@@ -29,6 +30,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             + "(:author is null or :author = u.profile.username.name) "
             + "order by a.createdAt"
     )
-    Page<Article> findPageByTagAndAuthor(Pageable pageable, String tag, String author);
+    Page<Article> findPageByTagAndAuthor(Pageable pageable, @Param("tag") String tag, @Param("author") String author);
 
 }

--- a/src/main/java/com/study/realworld/global/exception/ErrorCode.java
+++ b/src/main/java/com/study/realworld/global/exception/ErrorCode.java
@@ -43,6 +43,9 @@ public enum ErrorCode {
 
     // comment
     INVALID_COMMENT_BODY_NULL(HttpStatus.BAD_REQUEST, "body must be provided"),
+    INVALID_COMMENT_AUTHOR_DISMATCH(HttpStatus.BAD_REQUEST, "user is not comment's author"),
+
+    INVALID_COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "comment is not found by article and comment"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/study/realworld/global/exception/ErrorCode.java
+++ b/src/main/java/com/study/realworld/global/exception/ErrorCode.java
@@ -42,7 +42,7 @@ public enum ErrorCode {
     ARTICLE_NOT_FOUND_BY_SLUG(HttpStatus.BAD_REQUEST, "article is not found by slug"),
 
     // comment
-    INVALID_COMMENT_BODY_NULL(HttpStatus.BAD_REQUEST, "body must be provided"),w
+    INVALID_COMMENT_BODY_NULL(HttpStatus.BAD_REQUEST, "body must be provided"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/study/realworld/global/exception/ErrorCode.java
+++ b/src/main/java/com/study/realworld/global/exception/ErrorCode.java
@@ -40,6 +40,9 @@ public enum ErrorCode {
 
     ARTICLE_NOT_FOUND_BY_AUTHOR_AND_SLUG(HttpStatus.BAD_REQUEST, "article is not found by author and slug"),
     ARTICLE_NOT_FOUND_BY_SLUG(HttpStatus.BAD_REQUEST, "article is not found by slug"),
+
+    // comment
+    INVALID_COMMENT_BODY_NULL(HttpStatus.BAD_REQUEST, "body must be provided"),w
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/study/realworld/article/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/study/realworld/article/comment/controller/CommentControllerTest.java
@@ -1,0 +1,160 @@
+package com.study.realworld.article.comment.controller;
+
+import static com.study.realworld.user.controller.ApiDocumentUtils.getDocumentRequest;
+import static com.study.realworld.user.controller.ApiDocumentUtils.getDocumentResponse;
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ofPattern;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.study.realworld.article.comment.domain.Comment;
+import com.study.realworld.article.comment.domain.CommentBody;
+import com.study.realworld.article.comment.service.CommentService;
+import com.study.realworld.article.domain.Article;
+import com.study.realworld.article.domain.ArticleContent;
+import com.study.realworld.article.domain.Body;
+import com.study.realworld.article.domain.Description;
+import com.study.realworld.article.domain.SlugTitle;
+import com.study.realworld.article.domain.Title;
+import com.study.realworld.tag.domain.Tag;
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.Password;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.Username;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
+class CommentControllerTest {
+
+    @Mock
+    private CommentService commentService;
+
+    @InjectMocks
+    private CommentController commentController;
+
+    private MockMvc mockMvc;
+
+    private User author;
+    private Article article;
+
+    @BeforeEach
+    void beforeEach(RestDocumentationContextProvider restDocumentationContextProvider) {
+        SecurityContextHolder.clearContext();
+        mockMvc = MockMvcBuilders.standaloneSetup(commentController)
+            .apply(documentationConfiguration(restDocumentationContextProvider))
+            .alwaysExpect(status().isOk())
+            .build();
+
+        author = User.Builder()
+            .profile(Username.of("username"), null, null)
+            .email(Email.of("email@email.com"))
+            .password(Password.of("password"))
+            .build();
+        ArticleContent articleContent = ArticleContent.builder()
+            .slugTitle(SlugTitle.of(Title.of("title title title")))
+            .description(Description.of("test article description"))
+            .body(Body.of("test article body"))
+            .tags(Arrays.asList(Tag.of("tag1"), Tag.of("tag2")))
+            .build();
+        article = Article.from(articleContent, author);
+    }
+
+    @Test
+    void createCommentTest() throws Exception {
+
+        // setup
+        Comment comment = Comment.from(CommentBody.of("His name was my name too."), author, article);
+        ReflectionTestUtils.setField(comment, "id", 1L);
+
+        OffsetDateTime now = OffsetDateTime.now();
+        ReflectionTestUtils.setField(comment, "createdAt", now);
+        ReflectionTestUtils.setField(comment, "updatedAt", now);
+
+        when(commentService.createComment(any(), eq(article.slug()), any())).thenReturn(comment);
+
+        // given
+        final String URL = "/api/articles/{slug}/comments";
+        final String content = "{\n"
+            + "  \"comment\": {\n"
+            + "    \"body\": \"His name was my name too.\"\n"
+            + "  }\n"
+            + "}";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(URL, article.slug().slug())
+            .content(content)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+            .andExpect(jsonPath("$.comment.id", is(comment.id().intValue())))
+            .andExpect(jsonPath("$.comment.createdAt",
+                is(comment.createdAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
+            .andExpect(jsonPath("$.comment.updatedAt",
+                is(comment.updatedAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
+            .andExpect(jsonPath("$.comment.body", is(comment.commentBody().body())))
+            .andExpect(jsonPath("$.comment.author.username", is(article.author().username().value())))
+            .andExpect(jsonPath("$.comment.author.bio", is(nullValue())))
+            .andExpect(jsonPath("$.comment.author.image", is(nullValue())))
+            .andExpect(jsonPath("$.comment.author.following", is(false)))
+
+            .andDo(document("comment-create",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestFields(
+                    fieldWithPath("comment.body").type(JsonFieldType.STRING).description("comment body")
+                ),
+                responseFields(
+                    fieldWithPath("comment.id").type(JsonFieldType.NUMBER).description("created comment's id"),
+                    fieldWithPath("comment.createdAt").type(JsonFieldType.STRING)
+                        .description("created comment's create time"),
+                    fieldWithPath("comment.updatedAt").type(JsonFieldType.STRING)
+                        .description("created comment's update time"),
+                    fieldWithPath("comment.body").type(JsonFieldType.STRING).description("created comment's body"),
+
+                    fieldWithPath("comment.author.username").type(JsonFieldType.STRING)
+                        .description("author's username"),
+                    fieldWithPath("comment.author.bio").type(JsonFieldType.STRING).description("author's bio")
+                        .optional(),
+                    fieldWithPath("comment.author.image").type(JsonFieldType.STRING).description("author's image")
+                        .optional(),
+                    fieldWithPath("comment.author.following").type(JsonFieldType.BOOLEAN)
+                        .description("author's following")
+                )
+            ))
+        ;
+    }
+}

--- a/src/test/java/com/study/realworld/article/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/study/realworld/article/comment/controller/CommentControllerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -228,6 +229,30 @@ class CommentControllerTest {
                     fieldWithPath("comment.author.following").type(JsonFieldType.BOOLEAN)
                         .description("author's following")
                 )
+            ))
+        ;
+    }
+
+    @Test
+    void deleteCommentTest() throws Exception {
+
+        // given
+        String slug = "title-title-title";
+        Long id = 1L;
+        final String URL = "/api/articles/{slug}/comments/{id}";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(delete(URL, slug, id)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+
+            .andDo(document("comment-delete",
+                getDocumentRequest(),
+                getDocumentResponse()
             ))
         ;
     }

--- a/src/test/java/com/study/realworld/article/comment/controller/response/CommentResponseTest.java
+++ b/src/test/java/com/study/realworld/article/comment/controller/response/CommentResponseTest.java
@@ -1,0 +1,12 @@
+package com.study.realworld.article.comment.controller.response;
+
+import org.junit.jupiter.api.Test;
+
+class CommentResponseTest {
+
+    @Test
+    void commentResponseTest() {
+        CommentResponse commentResponse = new CommentResponse();
+    }
+
+}

--- a/src/test/java/com/study/realworld/article/comment/controller/response/CommentsResponseTest.java
+++ b/src/test/java/com/study/realworld/article/comment/controller/response/CommentsResponseTest.java
@@ -8,4 +8,5 @@ class CommentsResponseTest {
     void commentsResponseTest() {
         CommentsResponse commentsResponse = new CommentsResponse();
     }
-    }
+
+}

--- a/src/test/java/com/study/realworld/article/comment/controller/response/CommentsResponseTest.java
+++ b/src/test/java/com/study/realworld/article/comment/controller/response/CommentsResponseTest.java
@@ -1,0 +1,11 @@
+package com.study.realworld.article.comment.controller.response;
+
+import org.junit.jupiter.api.Test;
+
+class CommentsResponseTest {
+
+    @Test
+    void commentsResponseTest() {
+        CommentsResponse commentsResponse = new CommentsResponse();
+    }
+    }

--- a/src/test/java/com/study/realworld/article/comment/domain/CommentBodyTest.java
+++ b/src/test/java/com/study/realworld/article/comment/domain/CommentBodyTest.java
@@ -1,0 +1,46 @@
+package com.study.realworld.article.comment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.study.realworld.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+
+public class CommentBodyTest {
+
+    @Test
+    void bodyTest() {
+        CommentBody body = new CommentBody();
+    }
+
+    @NullSource
+    @ParameterizedTest
+    @DisplayName("body가 null이 들어올 경우 exception이 발생해야 한다.")
+    void bodyNullExceptionTest(String input) {
+
+        // when & then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> CommentBody.of(input))
+            .withMessageMatching(ErrorCode.INVALID_COMMENT_BODY_NULL.getMessage());
+    }
+
+    @Test
+    @DisplayName("equals hashCode 테스트")
+    void bodyEqualsHashCodeTest() {
+
+        // given
+        String input = "body";
+
+        // when
+        CommentBody result = CommentBody.of(input);
+
+        // then
+        assertThat(result)
+            .isEqualTo(CommentBody.of(input))
+            .hasSameHashCodeAs(CommentBody.of(input));
+    }
+
+}

--- a/src/test/java/com/study/realworld/article/comment/domain/CommentTest.java
+++ b/src/test/java/com/study/realworld/article/comment/domain/CommentTest.java
@@ -15,6 +15,7 @@ import com.study.realworld.user.domain.Image;
 import com.study.realworld.user.domain.Password;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.Username;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,6 +47,23 @@ public class CommentTest {
     @Test
     void commentTest() {
         Comment comment = new Comment();
+    }
+
+    @Test
+    @DisplayName("Comment를 삭제할 때 삭제 시간을 저장할 수 있다.")
+    void deleteCommentTest() {
+
+        // given
+        Comment comment = Comment.from(commentBody, author, article);
+        OffsetDateTime startTime = OffsetDateTime.now();
+        comment.deleteComment();
+        OffsetDateTime endTime = OffsetDateTime.now();
+
+        // when
+        OffsetDateTime result = comment.deletedAt();
+
+        // then
+        assertThat(result).isAfter(startTime).isBefore(endTime);
     }
 
     @Test

--- a/src/test/java/com/study/realworld/article/comment/domain/CommentTest.java
+++ b/src/test/java/com/study/realworld/article/comment/domain/CommentTest.java
@@ -1,0 +1,64 @@
+package com.study.realworld.article.comment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.study.realworld.article.domain.Article;
+import com.study.realworld.article.domain.ArticleContent;
+import com.study.realworld.article.domain.Body;
+import com.study.realworld.article.domain.Description;
+import com.study.realworld.article.domain.SlugTitle;
+import com.study.realworld.article.domain.Title;
+import com.study.realworld.tag.domain.Tag;
+import com.study.realworld.user.domain.Bio;
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.Image;
+import com.study.realworld.user.domain.Password;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.Username;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+
+    private User author;
+    private Article article;
+    private CommentBody commentBody;
+
+    @BeforeEach
+    void beforeEach() {
+        author = User.Builder()
+            .email(Email.of("email@email.com"))
+            .password(Password.of("password"))
+            .profile(Username.of("username"), Bio.of("bio"), Image.of("image"))
+            .build();
+        ArticleContent articleContent = ArticleContent.builder()
+            .slugTitle(SlugTitle.of(Title.of("title")))
+            .description(Description.of("description"))
+            .body(Body.of("body"))
+            .tags(Arrays.asList(Tag.of("tag1"), Tag.of("tag2")))
+            .build();
+        article = Article.from(articleContent, author);
+        commentBody = CommentBody.of("comment body");
+    }
+
+    @Test
+    void commentTest() {
+        Comment comment = new Comment();
+    }
+
+    @Test
+    @DisplayName("equals hashCode 테스트")
+    void commentEqualsHashCodeTest() {
+
+        // when
+        Comment result = Comment.from(commentBody, author, article);
+
+        // then
+        assertThat(result)
+            .isEqualTo(Comment.from(commentBody, author, article))
+            .hasSameHashCodeAs(Comment.from(commentBody, author, article));
+    }
+
+}

--- a/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
@@ -25,8 +25,10 @@ import com.study.realworld.user.domain.Password;
 import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.Username;
 import com.study.realworld.user.service.UserService;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -162,6 +164,107 @@ class CommentServiceTest {
 
             // then
             assertThat(result).isEqualTo(expected);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("deleteCommentByCommentId Comment 삭제 기능 테스트")
+    class deleteCommentByCommentIdTest {
+
+        @Test
+        @DisplayName("로그인 유저가 없는 유저일 때 exception이 발생해야 한다.")
+        void deleteCommentByCommentIdExceptionByNotFoundUserTest() {
+
+            // setup & given
+            Long userId = 1L;
+            when(userService.findById(userId)).thenThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            // when & then
+            assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> commentService.deleteCommentByCommentId(userId, null, null))
+                .withMessageMatching(ErrorCode.USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글이 없는 게시글일 때 exception이 발생해야 한다.")
+        void deleteCommentByCommentIdExceptionByNotFoundArticleTest() {
+
+            // setup & given
+            Long userId = 1L;
+            Slug slug = Slug.of("title");
+            when(userService.findById(userId)).thenReturn(author);
+            when(articleService.findBySlug(slug)).thenThrow(new BusinessException(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG));
+
+            // when & then
+            assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> commentService.deleteCommentByCommentId(userId, slug, null))
+                .withMessageMatching(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG.getMessage());
+        }
+
+        @Test
+        @DisplayName("없는 comment일 때 exception이 발생해야 한다.")
+        void deleteCommentByCommentIdExceptionByNotFoundComment() {
+
+            // setup & given
+            Long userId = 1L;
+            Slug slug = Slug.of("title");
+            Long commentId = 2L;
+            when(userService.findById(userId)).thenReturn(author);
+            when(articleService.findBySlug(slug)).thenReturn(article);
+            when(commentRepository.findByIdAndArticle(commentId, article))
+                .thenThrow(new BusinessException(ErrorCode.INVALID_COMMENT_NOT_FOUND));
+
+            // when & then
+            assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> commentService.deleteCommentByCommentId(userId, slug, commentId))
+                .withMessageMatching(ErrorCode.INVALID_COMMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("comment 작성자와 유저가 다를 때 exception이 발생해야 한다.")
+        void deleteCommentByCommentIdExceptionByMissMatchUser() {
+
+            // setup & given
+            Long userId = 1L;
+            User user = User.Builder()
+                .email(Email.of("email1@email1.com"))
+                .build();
+            Slug slug = Slug.of("title");
+            Long commentId = 2L;
+            Comment comment = Comment.from(commentBody, author, article);
+            when(userService.findById(userId)).thenReturn(user);
+            when(articleService.findBySlug(slug)).thenReturn(article);
+            when(commentRepository.findByIdAndArticle(commentId, article)).thenReturn(Optional.of(comment));
+
+            // when & then
+            assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> commentService.deleteCommentByCommentId(userId, slug, commentId))
+                .withMessageMatching(ErrorCode.INVALID_COMMENT_AUTHOR_DISMATCH.getMessage());
+        }
+
+        @Test
+        @DisplayName("comment를 제거할 수 있다.")
+        void deleteCommentByCommentIdSuccessTest() {
+
+            // setup & given
+            Long userId = 1L;
+            Slug slug = Slug.of("title");
+            Long commentId = 2L;
+            Comment comment = Comment.from(commentBody, author, article);
+            when(userService.findById(userId)).thenReturn(author);
+            when(articleService.findBySlug(slug)).thenReturn(article);
+            when(commentRepository.findByIdAndArticle(commentId, article)).thenReturn(Optional.of(comment));
+
+            OffsetDateTime start = OffsetDateTime.now();
+            commentService.deleteCommentByCommentId(userId, slug, commentId);
+            OffsetDateTime end = OffsetDateTime.now();
+
+            // when
+            OffsetDateTime result = comment.deletedAt();
+
+            // then
+            assertThat(result).isAfter(start).isBefore(end);
         }
 
     }

--- a/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
@@ -1,8 +1,10 @@
 package com.study.realworld.article.comment.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
 
+import com.study.realworld.article.comment.domain.Comment;
 import com.study.realworld.article.comment.domain.CommentBody;
 import com.study.realworld.article.comment.domain.CommentRepository;
 import com.study.realworld.article.domain.Article;
@@ -101,6 +103,25 @@ class CommentServiceTest {
             assertThatExceptionOfType(BusinessException.class)
                 .isThrownBy(() -> commentService.createComment(userId, slug, null))
                 .withMessageMatching(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG.getMessage());
+        }
+
+        @Test
+        @DisplayName("comment를 생성할 수 있다.")
+        void createCommentSuccessTest() {
+
+            // setup & given
+            Long userId = 1L;
+            Slug slug = Slug.of("title");
+            when(userService.findById(userId)).thenReturn(author);
+            when(articleService.findBySlug(slug)).thenReturn(article);
+            Comment expected = Comment.from(commentBody, author, article);
+            when(commentRepository.save(expected)).thenReturn(expected);
+
+            // when
+            Comment result = commentService.createComment(userId, slug, commentBody);
+
+            // then
+            assertThat(result).isEqualTo(expected);
         }
 
     }

--- a/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
@@ -9,6 +9,7 @@ import com.study.realworld.article.domain.Article;
 import com.study.realworld.article.domain.ArticleContent;
 import com.study.realworld.article.domain.Body;
 import com.study.realworld.article.domain.Description;
+import com.study.realworld.article.domain.Slug;
 import com.study.realworld.article.domain.SlugTitle;
 import com.study.realworld.article.domain.Title;
 import com.study.realworld.article.service.ArticleService;
@@ -74,7 +75,7 @@ class CommentServiceTest {
 
         @Test
         @DisplayName("로그인 유저가 없는 유저일 때 exception이 발생해야 한다.")
-        void createCommentExceptionByNotFoundUser() {
+        void createCommentExceptionByNotFoundUserTest() {
 
             // setup & given
             Long userId = 1L;
@@ -84,6 +85,22 @@ class CommentServiceTest {
             assertThatExceptionOfType(BusinessException.class)
                 .isThrownBy(() -> commentService.createComment(userId, null, null))
                 .withMessageMatching(ErrorCode.USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("게시글이 없는 게시글일 때 exception이 발생해야 한다.")
+        void createCommentExceptionByNotFoundArticleTest() {
+
+            // setup & given
+            Long userId = 1L;
+            Slug slug = Slug.of("title");
+            when(userService.findById(userId)).thenReturn(author);
+            when(articleService.findBySlug(slug)).thenThrow(new BusinessException(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG));
+
+            // when & then
+            assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> commentService.createComment(userId, slug, null))
+                .withMessageMatching(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG.getMessage());
         }
 
     }

--- a/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
@@ -1,0 +1,91 @@
+package com.study.realworld.article.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import com.study.realworld.article.comment.domain.CommentBody;
+import com.study.realworld.article.comment.domain.CommentRepository;
+import com.study.realworld.article.domain.Article;
+import com.study.realworld.article.domain.ArticleContent;
+import com.study.realworld.article.domain.Body;
+import com.study.realworld.article.domain.Description;
+import com.study.realworld.article.domain.SlugTitle;
+import com.study.realworld.article.domain.Title;
+import com.study.realworld.article.service.ArticleService;
+import com.study.realworld.global.exception.BusinessException;
+import com.study.realworld.global.exception.ErrorCode;
+import com.study.realworld.tag.domain.Tag;
+import com.study.realworld.user.domain.Bio;
+import com.study.realworld.user.domain.Email;
+import com.study.realworld.user.domain.Image;
+import com.study.realworld.user.domain.Password;
+import com.study.realworld.user.domain.User;
+import com.study.realworld.user.domain.Username;
+import com.study.realworld.user.service.UserService;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ArticleService articleService;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    private User author;
+    private Article article;
+    private CommentBody commentBody;
+
+    @BeforeEach
+    void beforeEach() {
+        author = User.Builder()
+            .email(Email.of("email@email.com"))
+            .password(Password.of("password"))
+            .profile(Username.of("username"), Bio.of("bio"), Image.of("image"))
+            .build();
+        ArticleContent articleContent = ArticleContent.builder()
+            .slugTitle(SlugTitle.of(Title.of("title")))
+            .description(Description.of("description"))
+            .body(Body.of("body"))
+            .tags(Arrays.asList(Tag.of("tag1"), Tag.of("tag2")))
+            .build();
+        article = Article.from(articleContent, author);
+        commentBody = CommentBody.of("comment body");
+    }
+
+    @Nested
+    @DisplayName("createComment Comment 저장 기능 테스트")
+    class createCommentTest {
+
+        @Test
+        @DisplayName("로그인 유저가 없는 유저일 때 exception이 발생해야 한다.")
+        void createCommentExceptionByNotFoundUser() {
+
+            // setup & given
+            Long userId = 1L;
+            when(userService.findById(userId)).thenThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            // when & then
+            assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> commentService.createComment(userId, null, null))
+                .withMessageMatching(ErrorCode.USER_NOT_FOUND.getMessage());
+        }
+
+    }
+
+}

--- a/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/study/realworld/article/comment/service/CommentServiceTest.java
@@ -26,6 +26,7 @@ import com.study.realworld.user.domain.User;
 import com.study.realworld.user.domain.Username;
 import com.study.realworld.user.service.UserService;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -119,6 +120,45 @@ class CommentServiceTest {
 
             // when
             Comment result = commentService.createComment(userId, slug, commentBody);
+
+            // then
+            assertThat(result).isEqualTo(expected);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("getCommentsByArticleSlug comments 반환 테스트")
+    class getCommentsByArticleSlugTest {
+
+        @Test
+        @DisplayName("게시글이 없는 게시글일 때 exception이 발생해야 한다.")
+        void getCommentsByArticleSlugExceptionByNotFoundArticleTest() {
+
+            // setup & given
+            Slug slug = Slug.of("title");
+            when(articleService.findBySlug(slug)).thenThrow(new BusinessException(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG));
+
+            // when & then
+            assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> commentService.getCommentsByArticleSlug(slug))
+                .withMessageMatching(ErrorCode.ARTICLE_NOT_FOUND_BY_SLUG.getMessage());
+        }
+
+        @Test
+        @DisplayName("comments를 반환할 수 있다.")
+        void getCommentsByArticleSlugTest() {
+
+            // given
+            Slug slug = Slug.of("title");
+            when(articleService.findBySlug(slug)).thenReturn(article);
+            List<Comment> expected = Arrays.asList(Comment.from(commentBody, author, article),
+                Comment.from(commentBody, author, article),
+                Comment.from(commentBody, author, article));
+            when(commentRepository.findAllByArticle(article)).thenReturn(expected);
+
+            // when
+            List<Comment> result = commentService.getCommentsByArticleSlug(slug);
 
             // then
             assertThat(result).isEqualTo(expected);

--- a/src/test/java/com/study/realworld/article/controller/ArticleControllerTest.java
+++ b/src/test/java/com/study/realworld/article/controller/ArticleControllerTest.java
@@ -195,7 +195,7 @@ class ArticleControllerTest {
         // given
         final String URL = "/api/articles";
 
-        Article expectd = articleList.get(0);
+        Article expected = articleList.get(0);
 
         // when
         ResultActions resultActions = mockMvc.perform(get(URL)
@@ -213,17 +213,17 @@ class ArticleControllerTest {
 
             .andExpect(jsonPath("$.articles.size()", is(limit)))
 
-            .andExpect(jsonPath("$.articles.[0].slug", is(expectd.slug().slug())))
-            .andExpect(jsonPath("$.articles.[0].title", is(expectd.title().title())))
-            .andExpect(jsonPath("$.articles.[0].description", is(expectd.description().description())))
-            .andExpect(jsonPath("$.articles.[0].body", is(expectd.body().body())))
-            .andExpect(jsonPath("$.articles.[0].tagList.[0]", is(expectd.tags().get(0).name())))
-            .andExpect(jsonPath("$.articles.[0].tagList.[1]", is(expectd.tags().get(1).name())))
+            .andExpect(jsonPath("$.articles.[0].slug", is(expected.slug().slug())))
+            .andExpect(jsonPath("$.articles.[0].title", is(expected.title().title())))
+            .andExpect(jsonPath("$.articles.[0].description", is(expected.description().description())))
+            .andExpect(jsonPath("$.articles.[0].body", is(expected.body().body())))
+            .andExpect(jsonPath("$.articles.[0].tagList.[0]", is(expected.tags().get(0).name())))
+            .andExpect(jsonPath("$.articles.[0].tagList.[1]", is(expected.tags().get(1).name())))
             .andExpect(jsonPath("$.articles.[0].createdAt",
-                is(expectd.createdAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
+                is(expected.createdAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
             .andExpect(jsonPath("$.articles.[0].updatedAt",
-                is(expectd.updatedAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
-            .andExpect(jsonPath("$.articles.[0].author.username", is(expectd.author().username().value())))
+                is(expected.updatedAt().format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC)))))
+            .andExpect(jsonPath("$.articles.[0].author.username", is(expected.author().username().value())))
             .andExpect(jsonPath("$.articles.[0].author.bio", is(nullValue())))
             .andExpect(jsonPath("$.articles.[0].author.image", is(nullValue())))
             .andExpect(jsonPath("$.articles.[0].author.following", is(false)))


### PR DESCRIPTION
## Issue: #67

## 작업 내용
- `POST /api/articles/{slug}/comments`
- `GET /api/articles/{slug}/comments`
- `DELETE /api/articles/{slug}/comments/{id}`

## 생성/변경 로직
- comment's 도메인 구성
- comment 추가/삭제 관련 메소드 구현
